### PR TITLE
Add base workflow for generating doc artifacts

### DIFF
--- a/.github/workflows/generate-docs-artifacts.yml
+++ b/.github/workflows/generate-docs-artifacts.yml
@@ -1,0 +1,46 @@
+# This GitHub action can generate documentation artifacts for a release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+
+name: generate-docs-artifacts
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  snapshot-docs-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+      - run:  npx -p @hashicorp/packer-docs-artifacts generate
+      - name: Get Release Tag
+        id: tag_details
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+        shell: bash
+      - name: Create Pull Request with Generated Doc Artifacts
+        uses: peter-evans/create-pull-request@v3
+        with:
+          # See Action inputs https://github.com/peter-evans/create-pull-request#action-inputs
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # The base branch to open a pull-request against. By default the base branch matches
+          # the checked out branch. If not the default branch it should be adjust to main or master.
+          # see https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#events-which-checkout-a-commit
+          base: "main"
+          # The name of the branch that will be automatically created for the generated pull-request.
+          branch: "update-docs-artifacts-${{steps.tag_details.outputs.TAG}}"
+          title: "Update generated docs artifact cache for ${{steps.tag_details.outputs.TAG}}"
+          body: "Automated changes to update generated docs artifact cache for ${{steps.tag_details.outputs.TAG}}"
+          commit-message: "plugin/docs: update generated docs artifact cache"
+          # The committer name and email address in the format Display Name <email@address.com>.
+          # Defaults to GitHub, you may need to change this in cases where committers must sign a CLA.
+          committer: "packer-ci <62970560+packer-ci@users.noreply.github.com"
+          # Comment out the author field if you would like to change the author of the pull-request.
+          # Defaults to the name of the user who triggered the event - created the tag.
+          author: "packer-ci"
+          # Comment out the labels field to automatically apply a common separated list of labels to the created pull-request.
+          # labels
+          delete-branch: true
+
+


### PR DESCRIPTION
Adding workflow for generating docs artifacts on release. This step is needed in order for remote plugin docs to get ingested into Packer.io :partying_face: 

Requires https://github.com/hashicorp/packer/pull/10656/

To actually add the files to Packer.io we need to open a PR against `website/data/docs-remote-plugins.json` in the Packer repo with a block that looks like this

```json

  {
    "title": "Docker",
    "path": "docker",
    "repo": "hashicorp/packer-plugin-docker"
  }
```