### PR TITLE
Post-Procesor hcl examples and misspelling fixes

### DIFF
--- a/docs/post-processors/docker-save.mdx
+++ b/docs/post-processors/docker-save.mdx
@@ -56,7 +56,7 @@ An example is shown below, showing only the post-processor configuration:
 <Tab heading="HCL2">
 
 ```hcl
-post-processors "docker-save" {
+post-processor "docker-save" {
   path = "foo.tar"
 }
 ```

--- a/docs/post-processors/docker-tag.mdx
+++ b/docs/post-processors/docker-tag.mdx
@@ -65,7 +65,7 @@ An example is shown below, showing only the post-processor configuration:
 <Tab heading="HCL2">
 
 ```hcl
-post-processors "docker-tag" {
+post-processor "docker-tag" {
   repository = "hashicorp/packer"
   tag = "0.7,anothertag"
 }

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -21,7 +21,7 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	Repository string `mapstructure:"repository"`
-	// Kept for backwards compatability
+	// Kept for backwards compatibility
 	Tag   []string `mapstructure:"tag"`
 	Tags  []string `mapstructure:"tags"`
 	Force bool

--- a/post-processor/docker-tag/post-processor_test.go
+++ b/post-processor/docker-tag/post-processor_test.go
@@ -190,7 +190,7 @@ func TestPostProcessor_PostProcess_Tag_vs_Tags(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 		assert.ElementsMatchf(t, p.config.Tags, []string{"bar", "buzz", "bang"},
-			"tag and tags fields should be combined into tags fields. Recieved: %#v",
+			"tag and tags fields should be combined into tags fields. Received: %#v",
 			p.config.Tags)
 	}
 }


### PR DESCRIPTION
Hi there,

Noticed a few issues on the main repo of packer, but realized this has since been moved to a new repo, so opening up a fresh PR against this one!

This PR contains:

- docs: fix post-processor hcl examples for docker-save and docker-tag postprocessors.
- fix code comment misspelling.
- fix misspelling in assertion.

Cheers!