### PR TITLE
Update goreleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,8 @@ builds:
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 archives:
 - format: zip
+  files:
+    - none*
   name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
This changes removes the README and CHANGELOG files from the release
binary. The released archive should only be a single multi-component plugin
binary file that can be consumed by Packer.

Closes #25
