### PR TITLE
fix: update examples to match and fix syntax

### DIFF
--- a/docs/post-processors/docker-tag.mdx
+++ b/docs/post-processors/docker-tag.mdx
@@ -57,7 +57,7 @@ An example is shown below, showing only the post-processor configuration:
 {
   "type": "docker-tag",
   "repository": "hashicorp/packer",
-  "tag": "0.7,anothertag"
+  "tags": ["0.7", "anothertag"]
 }
 ```
 </Tab>
@@ -67,7 +67,7 @@ An example is shown below, showing only the post-processor configuration:
 ```hcl
 post-processor "docker-tag" {
   repository = "hashicorp/packer"
-  tag = "0.7,anothertag"
+  tags = ["0.7", "anothertag"]
 }
 ```
 </Tab>


### PR DESCRIPTION
Doc change: Examples were outdated and had wrong syntax
