### PR TITLE
Fix wrong hcl docker-import post-processor example

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -364,7 +364,7 @@ of post-processors that are treated as as single pipeline, see
   post-processors {
     post-processor "docker-import" {
         repository =  "myrepo/myimage"
-        tag = ["0.7"]
+        tag = "0.7"
       }
     post-processor "docker-push" {}
   }
@@ -426,7 +426,7 @@ information):
   post-processors {
     post-processor "docker-tag" {
         repository =  "myrepo/myimage"
-        tag = ["0.7"]
+        tag = "0.7"
       }
     post-processor "docker-push" {}
   }
@@ -480,14 +480,14 @@ nearly-identical sequence definitions, as demonstrated by the example below:
   post-processors {
     post-processor "docker-tag" {
         repository =  "myrepo/myimage1"
-        tag = ["0.7"]
+        tag = "0.7"
       }
     post-processor "docker-push" {}
   }
   post-processors {
     post-processor "docker-tag" {
         repository =  "myrepo/myimage2"
-        tag = ["0.7"]
+        tag = "0.7"
       }
     post-processor "docker-push" {}
   }
@@ -585,7 +585,7 @@ above and example configuration properties are shown below:
 post-processors {
   post-processor "docker-tag" {
       repository = "12345.dkr.ecr.us-east-1.amazonaws.com/packer"
-      tag = ["0.7"]
+      tag = "0.7"
   }
   post-processor "docker-push" {
       ecr_login = true


### PR DESCRIPTION
With the provided examples, packer threw the following error:
```
Error: Failed preparing post-processor-block "docker-import" ""

  on ./config.pkr.hcl line 64:
  (source code not available)

./config.pkr.hcl:66,13-23: Incorrect attribute value type; Inappropriate value
for attribute "tag": string required.



==> Wait completed after 2 microseconds

==> Builds finished but no artifacts were created.
```
