### PR TITLE
revert doc fixes

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -426,7 +426,7 @@ information):
   post-processors {
     post-processor "docker-tag" {
         repository =  "myrepo/myimage"
-        tag = "0.7"
+        tag = ["0.7"]
       }
     post-processor "docker-push" {}
   }
@@ -480,14 +480,14 @@ nearly-identical sequence definitions, as demonstrated by the example below:
   post-processors {
     post-processor "docker-tag" {
         repository =  "myrepo/myimage1"
-        tag = "0.7"
+        tag = ["0.7"]
       }
     post-processor "docker-push" {}
   }
   post-processors {
     post-processor "docker-tag" {
         repository =  "myrepo/myimage2"
-        tag = "0.7"
+        tag = ["0.7"]
       }
     post-processor "docker-push" {}
   }
@@ -585,7 +585,7 @@ above and example configuration properties are shown below:
 post-processors {
   post-processor "docker-tag" {
       repository = "12345.dkr.ecr.us-east-1.amazonaws.com/packer"
-      tag = "0.7"
+      tag = ["0.7"]
   }
   post-processor "docker-push" {
       ecr_login = true


### PR DESCRIPTION
Revert doc fixes that fixed a bit too many docs. It would probably be worth it to have everything be named `tags` here.