### PR TITLE
Replace error on digest errors after docker push with warning message…

### DIFF
--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -130,8 +130,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	// Store digest in state's generated data.
 	digest, err := driver.Digest(artifact.Id())
 	if err != nil {
-		err := fmt.Errorf("Error determining pushed Docker image digest")
-		ui.Error(err.Error())
+		ui.Message("Unable to determine pushed Docker image digest")
 	}
 
 	stateData := map[string]interface{}{"docker_tags": tags}

--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -130,7 +130,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	// Store digest in state's generated data.
 	digest, err := driver.Digest(artifact.Id())
 	if err != nil {
-		ui.Message("Unable to determine pushed Docker image digest")
+		ui.Message("Unable to determine digest for source image, ignoring it for now")
 	}
 
 	stateData := map[string]interface{}{"docker_tags": tags}


### PR DESCRIPTION
This PR replaces an error text when docker digest images are unavailable, this wouldn't cause the plugin to fail, just to display an error message, now it just warns the user instead of erroring.

Added a test called TestPostProcessor_PostProcess_digestWarning which mocks out a digest failure and validates that the new warning text is shown.

Its worth noting that @nywilken and I struggled to reproduce this error message during development, but Wilken has run into it before.

Closes https://github.com/hashicorp/packer-plugin-docker/issues/77

