### PR TITLE
Add runtime configuration option

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -75,6 +75,8 @@ type Config struct {
 	// defaults to false if not set.
 	Privileged bool `mapstructure:"privileged" required:"false"`
 	Pty        bool
+	// Set the container runtime.
+	Runtime string `mapstructure:"runtime" required:"false"`
 	// If true, the configured image will be pulled using `docker pull` prior
 	// to use. Otherwise, it is assumed the image already exists and can be
 	// used. This defaults to true if not set.

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -75,7 +75,12 @@ type Config struct {
 	// defaults to false if not set.
 	Privileged bool `mapstructure:"privileged" required:"false"`
 	Pty        bool
-	// Set the container runtime.
+	// Set the container runtime. A runtime different from the one installed
+	// by default with Docker (`runc`) must be installed and configured.
+	// The possible values are (non-exhaustive list):
+	// `runsc` for [gVisor](https://gvisor.dev/),
+	// `kata-runtime` for [Kata Containers](https://katacontainers.io/),
+	// `sysbox-runc` for [Nestybox](https://www.nestybox.com/).
 	Runtime string `mapstructure:"runtime" required:"false"`
 	// If true, the configured image will be pulled using `docker pull` prior
 	// to use. Otherwise, it is assumed the image already exists and can be

--- a/builder/docker/config.hcl2spec.go
+++ b/builder/docker/config.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	Message                   *string           `mapstructure:"message" required:"true" cty:"message" hcl:"message"`
 	Privileged                *bool             `mapstructure:"privileged" required:"false" cty:"privileged" hcl:"privileged"`
 	Pty                       *bool             `cty:"pty" hcl:"pty"`
+	Runtime                   *string           `mapstructure:"runtime" required:"false" cty:"runtime" hcl:"runtime"`
 	Pull                      *bool             `mapstructure:"pull" required:"false" cty:"pull" hcl:"pull"`
 	RunCommand                []string          `mapstructure:"run_command" required:"false" cty:"run_command" hcl:"run_command"`
 	TmpFs                     []string          `mapstructure:"tmpfs" required:"false" cty:"tmpfs" hcl:"tmpfs"`
@@ -181,6 +182,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"message":                      &hcldec.AttrSpec{Name: "message", Type: cty.String, Required: false},
 		"privileged":                   &hcldec.AttrSpec{Name: "privileged", Type: cty.Bool, Required: false},
 		"pty":                          &hcldec.AttrSpec{Name: "pty", Type: cty.Bool, Required: false},
+		"runtime":                      &hcldec.AttrSpec{Name: "runtime", Type: cty.String, Required: false},
 		"pull":                         &hcldec.AttrSpec{Name: "pull", Type: cty.Bool, Required: false},
 		"run_command":                  &hcldec.AttrSpec{Name: "run_command", Type: cty.List(cty.String), Required: false},
 		"tmpfs":                        &hcldec.AttrSpec{Name: "tmpfs", Type: cty.List(cty.String), Required: false},

--- a/builder/docker/driver.go
+++ b/builder/docker/driver.go
@@ -78,6 +78,7 @@ type ContainerConfig struct {
 	Volumes    map[string]string
 	TmpFs      []string
 	Privileged bool
+	Runtime    string
 }
 
 // This is the template that is used for the RunCommand in the ContainerConfig.

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -322,6 +322,9 @@ func (d *DockerDriver) StartContainer(config *ContainerConfig) (string, error) {
 	if config.Privileged {
 		args = append(args, "--privileged")
 	}
+	if config.Runtime != "" {
+		args = append(args, "--runtime", config.Runtime)
+	}
 	for _, v := range config.TmpFs {
 		args = append(args, "--tmpfs", v)
 	}

--- a/builder/docker/step_run.go
+++ b/builder/docker/step_run.go
@@ -31,6 +31,7 @@ func (s *StepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 		CapAdd:     config.CapAdd,
 		CapDrop:    config.CapDrop,
 		Privileged: config.Privileged,
+		Runtime:    config.Runtime,
 	}
 
 	for host, container := range config.Volumes {

--- a/docs-partials/builder/docker/Config-not-required.mdx
+++ b/docs-partials/builder/docker/Config-not-required.mdx
@@ -28,6 +28,8 @@
 - `privileged` (bool) - If true, run the docker container with the `--privileged` flag. This
   defaults to false if not set.
 
+- `runtime` (string) - Set the container runtime.
+
 - `pull` (bool) - If true, the configured image will be pulled using `docker pull` prior
   to use. Otherwise, it is assumed the image already exists and can be
   used. This defaults to true if not set.

--- a/docs-partials/builder/docker/Config-not-required.mdx
+++ b/docs-partials/builder/docker/Config-not-required.mdx
@@ -28,7 +28,12 @@
 - `privileged` (bool) - If true, run the docker container with the `--privileged` flag. This
   defaults to false if not set.
 
-- `runtime` (string) - Set the container runtime.
+- `runtime` (string) - Set the container runtime. A runtime different from the one installed
+  by default with Docker (`runc`) must be installed and configured.
+  The possible values are (non-exhaustive list):
+  `runsc` for [gVisor](https://gvisor.dev/),
+  `kata-runtime` for [Kata Containers](https://katacontainers.io/),
+  `sysbox-runc` for [Nestybox](https://www.nestybox.com/).
 
 - `pull` (bool) - If true, the configured image will be pulled using `docker pull` prior
   to use. Otherwise, it is assumed the image already exists and can be


### PR DESCRIPTION
In order to support other runtimes than runc, the `runtime` parameter is added to enable the `--runtime` option to the `docker run` command used to launch the container.