### PR TITLE
docker-push: use isolated client configuration

### DIFF
--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -225,13 +225,7 @@ func (d *DockerDriver) Login(repo, user, pass string) error {
 		return err
 	}
 
-	cmd := exec.Command("docker")
-
-	if d.ConfigDir != "" {
-		cmd.Args = append(cmd.Args, "--config", d.ConfigDir)
-	}
-
-	cmd.Args = append(cmd.Args, "login")
+	cmd := d.newCommandWithConfig("login")
 
 	if user != "" {
 		cmd.Args = append(cmd.Args, "-u", user)
@@ -270,17 +264,11 @@ func (d *DockerDriver) Login(repo, user, pass string) error {
 }
 
 func (d *DockerDriver) Logout(repo string) error {
-	cmd := exec.Command("docker")
+	cmd := d.newCommandWithConfig("logout")
 
-	if d.ConfigDir != "" {
-		cmd.Args = append(cmd.Args, "--config", d.ConfigDir)
-	}
-
-	args := []string{"logout"}
 	if repo != "" {
-		args = append(args, repo)
+		cmd.Args = append(cmd.Args, repo)
 	}
-	cmd.Args = append(cmd.Args, args...)
 
 	err := runAndStream(cmd, d.Ui)
 	d.l.Unlock()
@@ -288,24 +276,14 @@ func (d *DockerDriver) Logout(repo string) error {
 }
 
 func (d *DockerDriver) Pull(image string) error {
-	cmd := exec.Command("docker")
+	cmd := d.newCommandWithConfig("pull", image)
 
-	if d.ConfigDir != "" {
-		cmd.Args = append(cmd.Args, "--config", d.ConfigDir)
-	}
-
-	cmd.Args = append(cmd.Args, "pull", image)
 	return runAndStream(cmd, d.Ui)
 }
 
 func (d *DockerDriver) Push(name string) error {
-	cmd := exec.Command("docker")
+	cmd := d.newCommandWithConfig("push", name)
 
-	if d.ConfigDir != "" {
-		cmd.Args = append(cmd.Args, "--config", d.ConfigDir)
-	}
-
-	cmd.Args = append(cmd.Args, "push", name)
 	return runAndStream(cmd, d.Ui)
 }
 
@@ -477,4 +455,16 @@ func (d *DockerDriver) Version() (*version.Version, error) {
 	}
 
 	return version.NewVersion(string(match[0]))
+}
+
+func (d *DockerDriver) newCommandWithConfig(args ...string) *exec.Cmd {
+	cmd := exec.Command("docker")
+
+	if d.ConfigDir != "" {
+		cmd.Args = append(cmd.Args, "--config", d.ConfigDir)
+	}
+
+	cmd.Args = append(cmd.Args, args...)
+
+	return cmd
 }

--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -70,7 +70,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 
 	driver := p.Driver
 	if driver == nil {
-		var tmpConfigDir string
+		var configDir string
 
 		if _, ok := os.LookupEnv("DOCKER_CONFIG"); !ok {
 			ui.Message("Creating temporary Docker configuration directory")
@@ -79,7 +79,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 				return nil, false, false, fmt.Errorf(
 					"Error creating temporary Docker configuration directory: %s", err)
 			}
-			tmpConfigDir = tmpDir
+			configDir = tmpDir
 
 			defer func() {
 				ui.Message("Removing temporary Docker configuration directory")
@@ -94,7 +94,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		driver = &docker.DockerDriver{
 			Ctx:       &p.config.ctx,
 			Ui:        ui,
-			ConfigDir: tmpConfigDir,
+			ConfigDir: configDir,
 		}
 	}
 

--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -70,26 +70,31 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 
 	driver := p.Driver
 	if driver == nil {
-		ui.Message("Creating temporary Docker configuration directory")
-		tmpCfgDir, err := os.MkdirTemp("", "packer")
-		if err != nil {
-			return nil, false, false, fmt.Errorf(
-				"Error creating temporary Docker configuration directory: %s", err)
-		}
+		var tmpConfigDir string
 
-		defer func() {
-			ui.Message("Removing temporary Docker configuration directory")
-			if err := os.RemoveAll(tmpCfgDir); err != nil {
-				ui.Error(
-					fmt.Sprintf("Error removing temporary Docker configuration directory: %s", err))
+		if _, ok := os.LookupEnv("DOCKER_CONFIG"); !ok {
+			ui.Message("Creating temporary Docker configuration directory")
+			tmpDir, err := os.MkdirTemp("", "packer")
+			if err != nil {
+				return nil, false, false, fmt.Errorf(
+					"Error creating temporary Docker configuration directory: %s", err)
 			}
-		}()
+			tmpConfigDir = tmpDir
+
+			defer func() {
+				ui.Message("Removing temporary Docker configuration directory")
+				if err := os.RemoveAll(tmpDir); err != nil {
+					ui.Error(
+						fmt.Sprintf("Error removing temporary Docker configuration directory: %s", err))
+				}
+			}()
+		}
 
 		// If no driver is set, then we use the real driver
 		driver = &docker.DockerDriver{
 			Ctx:       &p.config.ctx,
 			Ui:        ui,
-			ConfigDir: tmpCfgDir,
+			ConfigDir: tmpConfigDir,
 		}
 	}
 


### PR DESCRIPTION
When running multiple `docker-push` post processors concurrently, there
was a race condition where one `docker-push` post processor would finish
and call `docker logout` to  remove the credentials for a given registry
while another `docker-push` post processor was still running, causing
the other `docker-push` post processor to no longer have access to the
registry credentials to perform a `docker push`.

Since the underlying `DockerDriver` shells out to raw `docker` commands,
calls to `Login` store registry credentials in the default Docker client
configuration directory. Additionally, calls to `Logout` remove registry
credentials from the default Docker client configuration directory.
Since Packer post processors are unaware of each other, one
`docker-push` post processor was removing registry credentials that
another `docker-push` post processor relied on.

These changes modify the `docker-push` post processor to use a
temporary, isolated Docker client configuration directory. This allows
each `docker-push` post processor to store registry credentials in an
isolated file that will not be accessed by another `docker-push` post
processor.

The implementation not modify the `Driver` interface, choosing instead
to add an exported field to the `DockerDriver` type that the
`docker-push` sets.

Closes #81 