### PR TITLE
Support `--platform` docker CLI argument to target the platform specific image architecture

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -112,6 +112,8 @@ type Config struct {
 	// running on a windows host. This is necessary for building Windows
 	// containers, because our normal docker bindings do not work for them.
 	WindowsContainer bool `mapstructure:"windows_container" required:"false"`
+	// Set platform if server is multi-platform capable
+	Platform string `mapstructure:"platform" required:"false"`
 
 	// This is used to login to dockerhub to pull a private base container. For
 	// pushing to dockerhub, see the docker post-processors

--- a/builder/docker/config.hcl2spec.go
+++ b/builder/docker/config.hcl2spec.go
@@ -88,6 +88,7 @@ type FlatConfig struct {
 	Volumes                   map[string]string `mapstructure:"volumes" required:"false" cty:"volumes" hcl:"volumes"`
 	FixUploadOwner            *bool             `mapstructure:"fix_upload_owner" required:"false" cty:"fix_upload_owner" hcl:"fix_upload_owner"`
 	WindowsContainer          *bool             `mapstructure:"windows_container" required:"false" cty:"windows_container" hcl:"windows_container"`
+	Platform                  *string           `mapstructure:"platform" required:"false" cty:"platform" hcl:"platform"`
 	Login                     *bool             `mapstructure:"login" required:"false" cty:"login" hcl:"login"`
 	LoginPassword             *string           `mapstructure:"login_password" required:"false" cty:"login_password" hcl:"login_password"`
 	LoginServer               *string           `mapstructure:"login_server" required:"false" cty:"login_server" hcl:"login_server"`
@@ -189,6 +190,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"volumes":                      &hcldec.AttrSpec{Name: "volumes", Type: cty.Map(cty.String), Required: false},
 		"fix_upload_owner":             &hcldec.AttrSpec{Name: "fix_upload_owner", Type: cty.Bool, Required: false},
 		"windows_container":            &hcldec.AttrSpec{Name: "windows_container", Type: cty.Bool, Required: false},
+		"platform":                     &hcldec.AttrSpec{Name: "platform", Type: cty.String, Required: false},
 		"login":                        &hcldec.AttrSpec{Name: "login", Type: cty.Bool, Required: false},
 		"login_password":               &hcldec.AttrSpec{Name: "login_password", Type: cty.String, Required: false},
 		"login_server":                 &hcldec.AttrSpec{Name: "login_server", Type: cty.String, Required: false},

--- a/builder/docker/driver.go
+++ b/builder/docker/driver.go
@@ -20,7 +20,7 @@ type Driver interface {
 	Export(id string, dst io.Writer) error
 
 	// Import imports a container from a tar file
-	Import(path string, changes []string, repo string) (string, error)
+	Import(path string, changes []string, repo string, platform string) (string, error)
 
 	// IPAddress returns the address of the container that can be used
 	// for external access.
@@ -40,10 +40,10 @@ type Driver interface {
 	Logout(repo string) error
 
 	// Pull should pull down the given image.
-	Pull(image string) error
+	Pull(image string, platform string) error
 
 	// Push pushes an image to a Docker index/registry.
-	Push(name string) error
+	Push(name string, platform string) error
 
 	// Save an image with the given ID to the given writer.
 	SaveImage(id string, dst io.Writer) error
@@ -79,6 +79,7 @@ type ContainerConfig struct {
 	TmpFs      []string
 	Privileged bool
 	Runtime    string
+	Platform   string
 }
 
 // This is the template that is used for the RunCommand in the ContainerConfig.

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -101,13 +101,17 @@ func (d *DockerDriver) Export(id string, dst io.Writer) error {
 	return nil
 }
 
-func (d *DockerDriver) Import(path string, changes []string, repo string) (string, error) {
+func (d *DockerDriver) Import(path string, changes []string, repo string, platform string) (string, error) {
 	var stdout, stderr bytes.Buffer
 
 	args := []string{"import"}
 
 	for _, change := range changes {
 		args = append(args, "--change", change)
+	}
+
+	if platform != "" {
+		args = append(args, "--platform", platform)
 	}
 
 	args = append(args, "-")
@@ -275,14 +279,22 @@ func (d *DockerDriver) Logout(repo string) error {
 	return err
 }
 
-func (d *DockerDriver) Pull(image string) error {
+func (d *DockerDriver) Pull(image string, platform string) error {
 	cmd := d.newCommandWithConfig("pull", image)
+
+	if platform != "" {
+		cmd.Args = append(cmd.Args, "--platform", platform)
+	}
 
 	return runAndStream(cmd, d.Ui)
 }
 
-func (d *DockerDriver) Push(name string) error {
+func (d *DockerDriver) Push(name string, platform string) error {
 	cmd := d.newCommandWithConfig("push", name)
+
+	if platform != "" {
+		cmd.Args = append(cmd.Args, "--platform", platform)
+	}
 
 	return runAndStream(cmd, d.Ui)
 }
@@ -330,6 +342,9 @@ func (d *DockerDriver) StartContainer(config *ContainerConfig) (string, error) {
 	}
 	if config.Runtime != "" {
 		args = append(args, "--runtime", config.Runtime)
+	}
+	if config.Platform != "" {
+		args = append(args, "--platform", config.Platform)
 	}
 	for _, v := range config.TmpFs {
 		args = append(args, "--tmpfs", v)

--- a/builder/docker/driver_mock.go
+++ b/builder/docker/driver_mock.go
@@ -17,11 +17,12 @@ type MockDriver struct {
 	DeleteImageId     string
 	DeleteImageErr    error
 
-	ImportCalled bool
-	ImportPath   string
-	ImportRepo   string
-	ImportId     string
-	ImportErr    error
+	ImportCalled   bool
+	ImportPath     string
+	ImportRepo     string
+	ImportId       string
+	ImportPlatform string
+	ImportErr      error
 
 	IPAddressCalled bool
 	IPAddressID     string
@@ -52,9 +53,10 @@ type MockDriver struct {
 	LogoutRepo   string
 	LogoutErr    error
 
-	PushCalled bool
-	PushName   string
-	PushErr    error
+	PushCalled   bool
+	PushName     string
+	PushPlatform string
+	PushErr      error
 
 	SaveImageCalled bool
 	SaveImageId     string
@@ -79,6 +81,7 @@ type MockDriver struct {
 	ExportID     string
 	PullCalled   bool
 	PullImage    string
+	PullPlatform string
 	StartCalled  bool
 	StartConfig  *ContainerConfig
 	StopCalled   bool
@@ -115,10 +118,11 @@ func (d *MockDriver) Export(id string, dst io.Writer) error {
 	return d.ExportError
 }
 
-func (d *MockDriver) Import(path string, changes []string, repo string) (string, error) {
+func (d *MockDriver) Import(path string, changes []string, repo string, platform string) (string, error) {
 	d.ImportCalled = true
 	d.ImportPath = path
 	d.ImportRepo = repo
+	d.ImportPlatform = platform
 	return d.ImportId, d.ImportErr
 }
 
@@ -154,15 +158,17 @@ func (d *MockDriver) Logout(r string) error {
 	return d.LogoutErr
 }
 
-func (d *MockDriver) Pull(image string) error {
+func (d *MockDriver) Pull(image string, platform string) error {
 	d.PullCalled = true
 	d.PullImage = image
+	d.PullPlatform = platform
 	return d.PullError
 }
 
-func (d *MockDriver) Push(name string) error {
+func (d *MockDriver) Push(name string, platform string) error {
 	d.PushCalled = true
 	d.PushName = name
+	d.PushPlatform = platform
 	return d.PushErr
 }
 

--- a/builder/docker/step_pull.go
+++ b/builder/docker/step_pull.go
@@ -93,7 +93,7 @@ func (s *StepPull) Run(ctx context.Context, state multistep.StateBag) multistep.
 		}()
 	}
 
-	if err := driver.Pull(config.Image); err != nil {
+	if err := driver.Pull(config.Image, config.Platform); err != nil {
 		err := fmt.Errorf("Error pulling Docker image: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/docker/step_run.go
+++ b/builder/docker/step_run.go
@@ -32,6 +32,7 @@ func (s *StepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 		CapDrop:    config.CapDrop,
 		Privileged: config.Privileged,
 		Runtime:    config.Runtime,
+		Platform:   config.Platform,
 	}
 
 	for host, container := range config.Volumes {

--- a/docs-partials/builder/docker/Config-not-required.mdx
+++ b/docs-partials/builder/docker/Config-not-required.mdx
@@ -65,6 +65,8 @@
   running on a windows host. This is necessary for building Windows
   containers, because our normal docker bindings do not work for them.
 
+- `platform` (string) - Set platform if server is multi-platform capable
+
 - `login` (bool) - This is used to login to dockerhub to pull a private base container. For
   pushing to dockerhub, see the docker post-processors
 

--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -296,6 +296,8 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
   running on a windows host. This is necessary for building Windows
   containers, because our normal docker bindings do not work for them.
 
+- `platform` (string) - Set platform if server is multi-platform capable.
+
 - `login` (bool) - This is used to login to dockerhub to pull a private base container. For
   pushing to dockerhub, see the docker post-processors
 

--- a/docs/post-processors/docker-import.mdx
+++ b/docs/post-processors/docker-import.mdx
@@ -88,6 +88,8 @@ is optional.
 - `keep_input_artifact` (boolean) - if true, do not delete the source tar
   after importing it to docker. Defaults to false.
 
+- `platform` (string) - Set platform if server is multi-platform capable.
+
 ## Example
 
 An example is shown below, showing only the post-processor configuration:

--- a/docs/post-processors/docker-push.mdx
+++ b/docs/post-processors/docker-push.mdx
@@ -45,6 +45,8 @@ This post-processor has only optional configuration:
   after pushing it to the cloud. Defaults to true, but can be set to false if
   you do not need to save your local copy of the docker container.
 
+- `platform` (string) - Set platform if server is multi-platform capable.
+
 - `login` (boolean) - Defaults to false. If true, the post-processor will
   login prior to pushing. For log into ECR see `ecr_login`.
 

--- a/post-processor/docker-import/post-processor.go
+++ b/post-processor/docker-import/post-processor.go
@@ -22,6 +22,7 @@ type Config struct {
 	Repository string   `mapstructure:"repository"`
 	Tag        string   `mapstructure:"tag"`
 	Changes    []string `mapstructure:"changes"`
+	Platform   string   `mapstructure:"platform"`
 
 	ctx interpolate.Context
 }
@@ -73,7 +74,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 
 	ui.Message("Importing image: " + artifact.Id())
 	ui.Message("Repository: " + importRepo)
-	id, err := driver.Import(artifact.Files()[0], p.config.Changes, importRepo)
+	id, err := driver.Import(artifact.Files()[0], p.config.Changes, importRepo, p.config.Platform)
 	if err != nil {
 		return nil, false, false, err
 	}

--- a/post-processor/docker-import/post-processor.hcl2spec.go
+++ b/post-processor/docker-import/post-processor.hcl2spec.go
@@ -21,6 +21,7 @@ type FlatConfig struct {
 	Repository          *string           `mapstructure:"repository" cty:"repository" hcl:"repository"`
 	Tag                 *string           `mapstructure:"tag" cty:"tag" hcl:"tag"`
 	Changes             []string          `mapstructure:"changes" cty:"changes" hcl:"changes"`
+	Platform            *string           `mapstructure:"platform" cty:"platform" hcl:"platform"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -46,6 +47,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"repository":                 &hcldec.AttrSpec{Name: "repository", Type: cty.String, Required: false},
 		"tag":                        &hcldec.AttrSpec{Name: "tag", Type: cty.String, Required: false},
 		"changes":                    &hcldec.AttrSpec{Name: "changes", Type: cty.List(cty.String), Required: false},
+		"platform":                   &hcldec.AttrSpec{Name: "platform", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -27,6 +27,7 @@ type Config struct {
 	LoginPassword          string `mapstructure:"login_password"`
 	LoginServer            string `mapstructure:"login_server"`
 	EcrLogin               bool   `mapstructure:"ecr_login"`
+	Platform               string `mapstructure:"platform"`
 	docker.AwsAccessConfig `mapstructure:",squash"`
 
 	ctx interpolate.Context
@@ -147,7 +148,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	// Get the name.
 	for _, name := range names {
 		ui.Message("Pushing: " + name)
-		if err := driver.Push(name); err != nil {
+		if err := driver.Push(name, p.config.Platform); err != nil {
 			return nil, false, false, err
 		}
 	}

--- a/post-processor/docker-push/post-processor.hcl2spec.go
+++ b/post-processor/docker-push/post-processor.hcl2spec.go
@@ -23,6 +23,7 @@ type FlatConfig struct {
 	LoginPassword       *string           `mapstructure:"login_password" cty:"login_password" hcl:"login_password"`
 	LoginServer         *string           `mapstructure:"login_server" cty:"login_server" hcl:"login_server"`
 	EcrLogin            *bool             `mapstructure:"ecr_login" cty:"ecr_login" hcl:"ecr_login"`
+	Platform            *string           `mapstructure:"platform" cty:"platform" hcl:"platform"`
 	AccessKey           *string           `mapstructure:"aws_access_key" required:"false" cty:"aws_access_key" hcl:"aws_access_key"`
 	SecretKey           *string           `mapstructure:"aws_secret_key" required:"false" cty:"aws_secret_key" hcl:"aws_secret_key"`
 	Token               *string           `mapstructure:"aws_token" required:"false" cty:"aws_token" hcl:"aws_token"`
@@ -54,6 +55,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"login_password":             &hcldec.AttrSpec{Name: "login_password", Type: cty.String, Required: false},
 		"login_server":               &hcldec.AttrSpec{Name: "login_server", Type: cty.String, Required: false},
 		"ecr_login":                  &hcldec.AttrSpec{Name: "ecr_login", Type: cty.Bool, Required: false},
+		"platform":                   &hcldec.AttrSpec{Name: "platform", Type: cty.String, Required: false},
 		"aws_access_key":             &hcldec.AttrSpec{Name: "aws_access_key", Type: cty.String, Required: false},
 		"aws_secret_key":             &hcldec.AttrSpec{Name: "aws_secret_key", Type: cty.String, Required: false},
 		"aws_token":                  &hcldec.AttrSpec{Name: "aws_token", Type: cty.String, Required: false},


### PR DESCRIPTION
Adding support for `--platform` arg on pull, push, import and run.

Closes #97

