### PR TITLE
Add ability to push/pull docker images to/from Amazon ECR Public Gallery

### DIFF
--- a/builder/docker/ecr_login.go
+++ b/builder/docker/ecr_login.go
@@ -5,7 +5,6 @@ package docker
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/ecrpublic"
 	"log"
 	"net/http"
 	"net/url"
@@ -16,6 +15,7 @@ import (
 	awsCredentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/ecrpublic"
 	awsbase "github.com/hashicorp/aws-sdk-go-base"
 	"github.com/hashicorp/go-cleanhttp"
 )

--- a/builder/docker/ecr_login.go
+++ b/builder/docker/ecr_login.go
@@ -88,7 +88,7 @@ func (c *AwsAccessConfig) PublicEcrLogin(ecrUrl string) (string, string, error) 
 	// the config.
 	creds, err := c.GetCredentials(config)
 	if err != nil {
-		return "", "", fmt.Errorf(err.Error())
+		return "", "", err
 	}
 	config.WithCredentials(creds)
 
@@ -119,7 +119,7 @@ func (c *AwsAccessConfig) PublicEcrLogin(ecrUrl string) (string, string, error) 
 
 	resp, err := service.GetAuthorizationToken(params)
 	if err != nil {
-		return "", "", fmt.Errorf(err.Error())
+		return "", "", err
 	}
 
 	auth, err := base64.StdEncoding.DecodeString(*resp.AuthorizationData.AuthorizationToken)
@@ -145,7 +145,7 @@ func (c *AwsAccessConfig) EcrGetLogin(ecrUrl string) (string, string, error) {
 	if parsingErr != nil {
 		errMsg := "failed to parse the ECR URL: %v" +
 			"\n%v" +
-			"\nit should be either on the form `public.ecr.aws/<registry_alias>/<registry_name>` or " +
+			"\nit should be either of the form `public.ecr.aws/<registry_alias>/<registry_name>` or " +
 			"`<account number>.dkr.ecr.<region>.amazonaws.com`"
 		return "", "", fmt.Errorf(errMsg, ecrUrl, parsingErr)
 	}

--- a/builder/docker/ecr_login.go
+++ b/builder/docker/ecr_login.go
@@ -109,10 +109,10 @@ func (c *AwsAccessConfig) PublicEcrLogin(ecrUrl string) (string, string, error) 
 	session := sess
 
 	cp, err := session.Config.Credentials.Get()
-
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create session: %s", err)
 	}
+	log.Printf("[INFO] AWS authentication used: %q", cp.ProviderName)
 
 	service := ecrpublic.New(session)
 	params := &ecrpublic.GetAuthorizationTokenInput{}

--- a/post-processor/docker-push/post-processor_test.go
+++ b/post-processor/docker-push/post-processor_test.go
@@ -32,6 +32,34 @@ func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
 	var _ packersdk.PostProcessor = new(PostProcessor)
 }
 
+func TestGetEcrType(t *testing.T) {
+	awsConfig := docker.AwsAccessConfig{}
+
+	typ, _ := awsConfig.GetEcrType("https://public.ecr.aws/j9y7g6y8/dev_hc_pkr_dkr_test_1")
+	if typ != docker.Public {
+		msg := fmt.Sprintf("ECR type should be %v", docker.Public)
+		t.Fatal(msg)
+	}
+
+	typ, _ = awsConfig.GetEcrType("https://public.ecr.aws/j9y7g6y8/dev_hc_pkr_dkr_test_1")
+	if typ != docker.Public {
+		msg := fmt.Sprintf("ECR type should be %v", docker.Public)
+		t.Fatal(msg)
+	}
+
+	typ, _ = awsConfig.GetEcrType("https://12345.dkr.ecr.us-east-1.amazonaws.com/private_dev_hc_pkr_dkr_test_1")
+	if typ != docker.Private {
+		msg := fmt.Sprintf("ECR type should be %v", docker.Private)
+		t.Fatal(msg)
+	}
+
+	typ, _ = awsConfig.GetEcrType("google.com")
+	if typ != docker.Invalid {
+		msg := fmt.Sprintf("ECR type should be %v", docker.Invalid)
+		t.Fatal(msg)
+	}
+}
+
 func TestPostProcessor_PostProcess(t *testing.T) {
 	driver := &docker.MockDriver{}
 	p := &PostProcessor{Driver: driver}


### PR DESCRIPTION
## Description
- This PR adds the ability to push docker images to [ECR Public](https://docs.aws.amazon.com/AmazonECR/latest/public/what-is-ecr.html)
- From the user's perspective, nothing has been changed. All they need to do is to use the ECR Public URI as the `login_server`.

## Sample Template for review
- Make sure to have right `aws` credentials set
```hcl
source "docker" "ubuntu-bionic" {
  image  = "ubuntu:bionic"
  commit = true
}

build {
  name = "docker-push-ecr-public"
  sources = [
    "source.docker.ubuntu-bionic"
  ]

  post-processors {
    post-processor "docker-tag" {
      repository = "public.ecr.aws/j9y7g6y8/dev_hc_pkr_dkr_test_1"
      tags       = ["packer-rocks", "burrito-boi"]
    }

    post-processor "docker-push" {
      ecr_login    = true
      aws_profile  = "default"
      login_server = "https://public.ecr.aws/j9y7g6y8/dev_hc_pkr_dkr_test_1"
    }
  }
}

```
 
Resolves: #45


