### PR TITLE
fix: Tabs syntax in docs

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -610,6 +610,7 @@ and example configuration properties are shown below:
 
 <Tabs>
 <Tab heading="JSON">
+
 ```json
     {
         "post-processors": [
@@ -630,6 +631,7 @@ and example configuration properties are shown below:
         ]
     }
 ```
+
 </Tab>
 <Tab heading="HCL2">
 


### PR DESCRIPTION
Fixes the syntax of the `Tabs` component usage in the builder docs.