### PR TITLE
Fix lint errors

### DIFF
--- a/builder/docker/ecr_login.go
+++ b/builder/docker/ecr_login.go
@@ -138,7 +138,7 @@ func (c *AwsAccessConfig) EcrGetLogin(ecrUrl string) (string, string, error) {
 	accountId := splitUrl[1]
 	region := splitUrl[2]
 
-	log.Println(fmt.Sprintf("Getting ECR token for account: %s in %s..", accountId, region))
+	log.Printf("Getting ECR token for account: %s in %s..", accountId, region)
 
 	// Create new AWS config
 	config := aws.NewConfig().WithCredentialsChainVerboseErrors(true)

--- a/post-processor/docker-push/post-processor_test.go
+++ b/post-processor/docker-push/post-processor_test.go
@@ -93,9 +93,6 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 	}
 
 	result, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
-	if _, ok := result.(packersdk.Artifact); !ok {
-		t.Fatal("should be instance of Artifact")
-	}
 	if !keep {
 		t.Fatal("should keep")
 	}
@@ -126,9 +123,6 @@ func TestPostProcessor_PostProcess_portInName(t *testing.T) {
 	}
 
 	result, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
-	if _, ok := result.(packersdk.Artifact); !ok {
-		t.Fatal("should be instance of Artifact")
-	}
 	if !keep {
 		t.Fatal("should keep")
 	}
@@ -159,9 +153,6 @@ func TestPostProcessor_PostProcess_tags(t *testing.T) {
 	}
 
 	result, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
-	if _, ok := result.(packersdk.Artifact); !ok {
-		t.Fatal("should be instance of Artifact")
-	}
 	if !keep {
 		t.Fatal("should keep")
 	}
@@ -196,9 +187,6 @@ func TestPostProcessor_PostProcess_digestWarning(t *testing.T) {
 	testUi := testUi()
 	result, keep, forceOverride, err := p.PostProcess(context.Background(), testUi, artifact)
 	resultString := readWriter(testUi)
-	if _, ok := result.(packersdk.Artifact); !ok {
-		t.Fatal("should be instance of Artifact")
-	}
 	if !keep {
 		t.Fatal("should keep")
 	}

--- a/post-processor/docker-tag/post-processor_test.go
+++ b/post-processor/docker-tag/post-processor_test.go
@@ -41,10 +41,7 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 		IdValue:        "1234567890abcdef",
 	}
 
-	result, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
-	if _, ok := result.(packersdk.Artifact); !ok {
-		t.Fatal("should be instance of Artifact")
-	}
+	_, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
 	if !keep {
 		t.Fatal("should keep")
 	}
@@ -89,10 +86,7 @@ func TestPostProcessor_PostProcess_Force(t *testing.T) {
 		IdValue:        "1234567890abcdef",
 	}
 
-	result, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
-	if _, ok := result.(packersdk.Artifact); !ok {
-		t.Fatal("should be instance of Artifact")
-	}
+	_, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
 	if !keep {
 		t.Fatal("should keep")
 	}
@@ -131,10 +125,7 @@ func TestPostProcessor_PostProcess_NoTag(t *testing.T) {
 
 	artifact := &packersdk.MockArtifact{BuilderIdValue: dockerimport.BuilderId, IdValue: "1234567890abcdef"}
 
-	result, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
-	if _, ok := result.(packersdk.Artifact); !ok {
-		t.Fatal("should be instance of Artifact")
-	}
+	_, keep, forceOverride, err := p.PostProcess(context.Background(), testUi(), artifact)
 	if !keep {
 		t.Fatal("should keep")
 	}


### PR DESCRIPTION
Running `golangci-lint` on the repository returns some errors, so we fix them in this PR.
