### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	// set to `true` or an `export_path` must be provided.
 	Commit bool `mapstructure:"commit" required:"true"`
 	// The directory inside container to mount temp directory from host server
-	// for work [file provisioner](/docs/provisioners/file). This defaults
+	// for work [file provisioner](/packer/docs/provisioners/file). This defaults
 	// to c:/packer-files on windows and /packer-files on other systems.
 	ContainerDir string `mapstructure:"container_dir" required:"false"`
 	// An array of devices which will be accessible in container when it's run
@@ -45,7 +45,7 @@ type Config struct {
 	Device []string `mapstructure:"device" required:"false"`
 	// Throw away the container when the build is complete. This is useful for
 	// the [artifice
-	// post-processor](/docs/post-processors/artifice).
+	// post-processor](/packer/docs/post-processors/artifice).
 	Discard bool `mapstructure:"discard" required:"true"`
 	// An array of additional [Linux
 	// capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)

--- a/docs-partials/builder/docker/Config-not-required.mdx
+++ b/docs-partials/builder/docker/Config-not-required.mdx
@@ -7,7 +7,7 @@
   /app", "EXPOSE 8080" ]
 
 - `container_dir` (string) - The directory inside container to mount temp directory from host server
-  for work [file provisioner](/docs/provisioners/file). This defaults
+  for work [file provisioner](/packer/docs/provisioners/file). This defaults
   to c:/packer-files on windows and /packer-files on other systems.
 
 - `device` ([]string) - An array of devices which will be accessible in container when it's run

--- a/docs-partials/builder/docker/Config-required.mdx
+++ b/docs-partials/builder/docker/Config-required.mdx
@@ -6,7 +6,7 @@
 
 - `discard` (bool) - Throw away the container when the build is complete. This is useful for
   the [artifice
-  post-processor](/docs/post-processors/artifice).
+  post-processor](/packer/docs/post-processors/artifice).
 
 - `export_path` (string) - The path where the final container will be exported as a tar file.
 

--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -200,7 +200,7 @@ optional. Within each category, the available options are alphabetized and
 described.
 
 The Docker builder uses a special Docker communicator _and will not use_ the
-standard [communicators](/docs/templates/legacy_json_templates/communicators).
+standard [communicators](/packer/docs/templates/legacy_json_templates/communicators).
 
 ### Required:
 
@@ -210,7 +210,7 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
 
 - `discard` (bool) - Throw away the container when the build is complete. This is useful for
   the [artifice
-  post-processor](/docs/post-processors/artifice).
+  post-processor](/packer/docs/post-processors/artifice).
 
 - `export_path` (string) - The path where the final container will be exported as a tar file.
 
@@ -245,7 +245,7 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
   /app", "EXPOSE 8080" ]
 
 - `container_dir` (string) - The directory inside container to mount temp directory from host server
-  for work [file provisioner](/docs/provisioners/file). This defaults
+  for work [file provisioner](/packer/docs/provisioners/file). This defaults
   to c:/packer-files on windows and /packer-files on other systems.
 
 - `device` ([]string) - An array of devices which will be accessible in container when it's run
@@ -315,8 +315,8 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
 
 ## Build Shared Information Variables
 
-This build shares generated data with provisioners and post-processors via [template engines](/docs/templates/legacy_json_templates/engine)
-for JSON and [contextual variables](/docs/templates/hcl_templates/contextual-variables) for HCL2.
+This build shares generated data with provisioners and post-processors via [template engines](/packer/docs/templates/legacy_json_templates/engine)
+for JSON and [contextual variables](/packer/docs/templates/hcl_templates/contextual-variables) for HCL2.
 
 The generated variable available for this builder is:
 
@@ -327,8 +327,8 @@ The generated variable available for this builder is:
 
 Once the tar artifact has been generated, you will likely want to import, tag,
 and push it to a container repository. Packer can do this for you automatically
-with the [docker-import](/docs/post-processors/docker-import) and
-[docker-push](/docs/post-processors/docker-push) post-processors.
+with the [docker-import](/packer/plugins/post-processors/docker/docker-import) and
+[docker-push](/packer/plugins/post-processors/docker/docker-push) post-processors.
 
 **Note:** This section is covering how to use an artifact that has been
 _exported_. More specifically, if you set `export_path` in your configuration.
@@ -337,7 +337,7 @@ If you set `commit`, see the next section.
 The example below shows a full configuration that would import and push the
 created image. This is accomplished using a sequence definition (a collection
 of post-processors that are treated as as single pipeline, see
-[Post-Processors](/docs/templates/legacy_json_templates/post-processors) for more information):
+[Post-Processors](/packer/docs/templates/legacy_json_templates/post-processors) for more information):
 
 <Tabs>
 <Tab heading="JSON">
@@ -398,7 +398,7 @@ If you committed your container to an image, you probably want to tag, save,
 push, etc. Packer can do this automatically for you. An example is shown below
 which tags and pushes an image. This is accomplished using a sequence
 definition (a collection of post-processors that are treated as as single
-pipeline, see [Post-Processors](/docs/templates/legacy_json_templates/post-processors) for more
+pipeline, see [Post-Processors](/packer/docs/templates/legacy_json_templates/post-processors) for more
 information):
 
 <Tabs>
@@ -655,7 +655,7 @@ and example configuration properties are shown below:
 </Tabs>
 
 [Learn how to set Amazon AWS
-credentials.](/docs/builders/amazon#specifying-amazon-credentials)
+credentials.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 ## Dockerfiles
 

--- a/docs/post-processors/docker-import.mdx
+++ b/docs/post-processors/docker-import.mdx
@@ -13,10 +13,10 @@ nav_title: Docker Import
 Type: `docker-import`
 
 The Packer Docker import post-processor takes an artifact from the [docker
-builder](/docs/builders/docker) and imports it with Docker locally. This
+builder](/packer/plugins/builders/docker) and imports it with Docker locally. This
 allows you to apply a repository and tag to the image and lets you use the
 other Docker post-processors such as
-[docker-push](/docs/post-processors/docker-push) to push the image to a
+[docker-push](/packer/plugins/post-processors/docker/docker-push) to push the image to a
 registry.
 
 ## Basic Example
@@ -122,7 +122,7 @@ This example would take the image created by the Docker builder and import it
 into the local Docker process with a name of `hashicorp/packer:0.7`.
 
 Following this, you can use the
-[docker-push](/docs/post-processors/docker-push) post-processor to push it
+[docker-push](/packer/plugins/post-processors/docker/docker-push) post-processor to push it
 to a registry, if you want.
 
 ## Changing Metadata

--- a/docs/post-processors/docker-push.mdx
+++ b/docs/post-processors/docker-push.mdx
@@ -11,7 +11,7 @@ nav_title: Docker Push
 Type: `docker-push`
 
 The Packer Docker push post-processor takes an artifact from the
-[docker-import](/docs/post-processors/docker-import) post-processor and
+[docker-import](/packer/plugins/post-processors/docker/docker-import) post-processor and
 pushes it to a Docker registry.
 
 ## Configuration
@@ -20,11 +20,11 @@ This post-processor has only optional configuration:
 
 - `aws_access_key` (string) - The AWS access key used to communicate with
   AWS. [Learn how to set
-  this.](/docs/builders/amazon#specifying-amazon-credentials)
+  this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `aws_secret_key` (string) - The AWS secret key used to communicate with
   AWS. [Learn how to set
-  this.](/docs/builders/amazon#specifying-amazon-credentials)
+  this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `aws_token` (string) - The AWS access token to use. This is different from
   the access key and secret key. If you're not sure what this is, then you
@@ -33,7 +33,7 @@ This post-processor has only optional configuration:
 
 - `aws_profile` (string) - The AWS shared credentials profile used to
   communicate with AWS. [Learn how to set
-  this.](/docs/builders/amazon#specifying-amazon-credentials)
+  this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `ecr_login` (boolean) - Defaults to false. If true, the post-processor will
   login in order to push the image to [Amazon EC2 Container Registry
@@ -72,4 +72,4 @@ will automatically log you out afterwards (just the server specified).
 ## Example
 
 For an example of using docker-push, see the section on using generated
-artifacts from the [docker builder](/docs/builders/docker).
+artifacts from the [docker builder](/packer/plugins/builders/docker).

--- a/docs/post-processors/docker-save.mdx
+++ b/docs/post-processors/docker-save.mdx
@@ -17,7 +17,7 @@ nav_title: Docker Save
 Type: `docker-save`
 
 The Packer Docker Save post-processor takes an artifact from the [docker
-builder](/docs/builders/docker) that was committed and saves it to a file.
+builder](/packer/plugins/builders/docker) that was committed and saves it to a file.
 This is similar to exporting the Docker image directly from the builder, except
 that it preserves the hierarchy of images and metadata.
 

--- a/docs/post-processors/docker-tag.mdx
+++ b/docs/post-processors/docker-tag.mdx
@@ -13,13 +13,13 @@ nav_title: Docker Tag
 Type: `docker-tag`
 
 The Packer Docker Tag post-processor takes an artifact from the [docker
-builder](/docs/builders/docker) that was committed and tags it into a
+builder](/packer/plugins/builders/docker) that was committed and tags it into a
 repository. This allows you to use the other Docker post-processors such as
-[docker-push](/docs/post-processors/docker-push) to push the image to a
+[docker-push](/packer/plugins/post-processors/docker/docker-push) to push the image to a
 registry.
 
 This is very similar to the
-[docker-import](/docs/post-processors/docker-import) post-processor except
+[docker-import](/packer/plugins/post-processors/docker/docker-import) post-processor except
 that this works with committed resources, rather than exported.
 
 ## Configuration
@@ -77,5 +77,5 @@ This example would take the image created by the Docker builder and tag it into
 the local Docker process with a name of `hashicorp/packer:0.7`.
 
 Following this, you can use the
-[docker-push](/docs/post-processors/docker-push) post-processor to push it
+[docker-push](/packer/plugins/post-processors/docker/docker-push) post-processor to push it
 to a registry, if you want.


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them
