### PR TITLE
Support "~/" in host volume path

### DIFF
--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+ 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -350,6 +351,10 @@ func (d *DockerDriver) StartContainer(config *ContainerConfig) (string, error) {
 		args = append(args, "--tmpfs", v)
 	}
 	for host, guest := range config.Volumes {
+		if strings.HasPrefix(host, "~/") {
+			homedir, _ := os.UserHomeDir()
+			host = filepath.Join(homedir, host[2:])
+		}
 		args = append(args, "-v", fmt.Sprintf("%s:%s", host, guest))
 	}
 	for _, v := range config.RunCommand {


### PR DESCRIPTION
## Support "~/" in host volume path

### Sample HCL code.

```hcl
source "docker" "docker" {
  image          = "amazonlinux"
  export_path    = "image.tar"
  privileged     = true
  aws_profile    = var.aws_profile
  volumes = {
    "~/.aws" = "/root/.aws"
  }
}
```

Closes #63 