### PR TITLE
Update ENTRYPOINT example

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -128,7 +128,7 @@ from ubuntu as an simple example:
     "LABEL version=1.0",
     "ONBUILD RUN date",
     "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
-    "ENTRYPOINT /var/www/start.sh"
+    "ENTRYPOINT [\"/docker-entrypoint.sh\"]"
   ]
 }
 ```
@@ -149,7 +149,7 @@ source "docker" "example" {
       "LABEL version=1.0",
       "ONBUILD RUN date",
       "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
-      "ENTRYPOINT /var/www/start.sh"
+      "ENTRYPOINT [\"/docker-entrypoint.sh\"]"
     ]
 }
 ```


### PR DESCRIPTION
Use the exec format for `ENTRYPOINT`. In the existing examples, the `CMD` option is using the exec format, but `ENTRYPOINT` is using the shell form. The example would essentially run `/bin/sh -c /var/www/start.sh` which wouldn't work.