### PR TITLE
[WIP] Fix premature logouts during parallel pushes

### DIFF
--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -121,13 +121,6 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 			return nil, false, false, fmt.Errorf(
 				"Error logging in to Docker: %s", err)
 		}
-
-		defer func() {
-			ui.Message("Logging out...")
-			if err := driver.Logout(p.config.LoginServer); err != nil {
-				ui.Error(fmt.Sprintf("Error logging out: %s", err))
-			}
-		}()
 	}
 
 	var tags []string


### PR DESCRIPTION
It seems the only thing to do here is just to remove the `docker logout`. This way, the `docker-push` works regardless of the number of post-processors run in parallel.

I don't think that the `docker logout` is needed, but perhaps I'm not aware of any negative consequences of skipping that.

If a user wanted to really logout at the end of the `packer build`, they could just do so manually. So maybe a documentation change may be warranted?

Closes https://github.com/hashicorp/packer-plugin-docker/issues/141