### PR TITLE
docs: fix windows image in example

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -536,7 +536,7 @@ container.
 
 ```hcl
 source "docker" "windows" {
-    image = "ubuntu"
+    image = "microsoft/windowsservercore:1709"
     container_dir = "c:/app"
     windows_container = true
     commit = true


### PR DESCRIPTION
For the Windows image example in HCL2, we described the image as `ubuntu' where it should have been a Windows image, so this commit fixes that problem by using the same image base as the JSON example.

Closes #153 

