### PR TITLE
docs: Add missing links to AWS credential guide

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -222,12 +222,10 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
 ### Optional:
 
 - `aws_access_key` (string) - The AWS access key used to communicate with
-  AWS. Learn how to set
-  this.
+  AWS. [Learn how to set this.](/packer/plugins/builders/amazon#specifying-amazon-credentials) 
 
 - `aws_secret_key` (string) - The AWS secret key used to communicate with
-  AWS. Learn how to set
-  this.
+  AWS. [Learn how to set this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `aws_token` (string) - The AWS access token to use. This is different from
   the access key and secret key. If you're not sure what this is, then you
@@ -235,8 +233,7 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
   environmental variable.
 
 - `aws_profile` (string) - The AWS shared credentials profile used to
-  communicate with AWS. Learn how to set
-  this.
+  communicate with AWS. [Learn how to set this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `author` (string) - Set the author (e-mail) of a commit.
 
@@ -654,8 +651,7 @@ and example configuration properties are shown below:
 </Tab>
 </Tabs>
 
-[Learn how to set Amazon AWS
-credentials.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
+[Learn how to set Amazon AWS credentials.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 ## Dockerfiles
 

--- a/docs/post-processors/docker-push.mdx
+++ b/docs/post-processors/docker-push.mdx
@@ -19,12 +19,10 @@ pushes it to a Docker registry.
 This post-processor has only optional configuration:
 
 - `aws_access_key` (string) - The AWS access key used to communicate with
-  AWS. [Learn how to set
-  this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
+  AWS. [Learn how to set this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `aws_secret_key` (string) - The AWS secret key used to communicate with
-  AWS. [Learn how to set
-  this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
+  AWS. [Learn how to set this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `aws_token` (string) - The AWS access token to use. This is different from
   the access key and secret key. If you're not sure what this is, then you
@@ -32,8 +30,7 @@ This post-processor has only optional configuration:
   environmental variable.
 
 - `aws_profile` (string) - The AWS shared credentials profile used to
-  communicate with AWS. [Learn how to set
-  this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
+  communicate with AWS. [Learn how to set this.](/packer/plugins/builders/amazon#specifying-amazon-credentials)
 
 - `ecr_login` (boolean) - Defaults to false. If true, the post-processor will
   login in order to push the image to [Amazon EC2 Container Registry


### PR DESCRIPTION
Adds some missing links to the AWS credential guide. 

Ran `make generate` after committing changes, which did not result in a diff, so I believe this should be sufficient. 