### PR TITLE
docs: Swap order of HCL2/JSON example code tabs so that the HCL2 tab is the default

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -73,17 +73,6 @@ running container, this one commits the container to an image. The image can
 then be more easily tagged, pushed, etc.
 
 <Tabs>
-<Tab heading="JSON">
-
-```json
-{
-  "type": "docker",
-  "image": "ubuntu",
-  "commit": true
-}
-```
-
-</Tab>
 <Tab heading="HCL2">
 
 ```hcl
@@ -94,6 +83,17 @@ source "docker" "example" {
 
 build {
   sources = ["source.docker.example"]
+}
+```
+
+</Tab>
+<Tab heading="JSON">
+
+```json
+{
+  "type": "docker",
+  "image": "ubuntu",
+  "commit": true
 }
 ```
 
@@ -557,6 +557,24 @@ Registry](https://aws.amazon.com/ecr/). The post processors work as described
 above and example configuration properties are shown below:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processors {
+  post-processor "docker-tag" {
+      repository = "12345.dkr.ecr.us-east-1.amazonaws.com/packer"
+      tags = ["0.7"]
+  }
+  post-processor "docker-push" {
+      ecr_login = true
+      aws_access_key = "YOUR KEY HERE"
+      aws_secret_key = "YOUR SECRET KEY HERE"
+      login_server = "12345.dkr.ecr.us-east-1.amazonaws.com"
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -577,24 +595,6 @@ above and example configuration properties are shown below:
       }
     ]
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-post-processors {
-  post-processor "docker-tag" {
-      repository = "12345.dkr.ecr.us-east-1.amazonaws.com/packer"
-      tags = ["0.7"]
-  }
-  post-processor "docker-push" {
-      ecr_login = true
-      aws_access_key = "YOUR KEY HERE"
-      aws_secret_key = "YOUR SECRET KEY HERE"
-      login_server = "12345.dkr.ecr.us-east-1.amazonaws.com"
-  }
 }
 ```
 

--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -43,8 +43,8 @@ provisioners are defined, but it will effectively repackage an image.
 
 ```hcl
 source "docker" "example" {
-    image = "ubuntu"
-    export_path = "image.tar"
+  image = "ubuntu"
+  export_path = "image.tar"
 }
 
 build {
@@ -77,8 +77,8 @@ then be more easily tagged, pushed, etc.
 
 ```hcl
 source "docker" "example" {
-    image = "ubuntu"
-    commit = true
+  image = "ubuntu"
+  commit = true
 }
 
 build {
@@ -116,19 +116,19 @@ from ubuntu as an simple example:
 
 ```hcl
 source "docker" "example" {
-    image = "ubuntu"
-    commit = true
-      changes = [
-      "USER www-data",
-      "WORKDIR /var/www",
-      "ENV HOSTNAME www.example.com",
-      "VOLUME /test1 /test2",
-      "EXPOSE 80 443",
-      "LABEL version=1.0",
-      "ONBUILD RUN date",
-      "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
-      "ENTRYPOINT /var/www/start.sh"
-    ]
+  image = "ubuntu"
+  commit = true
+  changes = [
+    "USER www-data",
+    "WORKDIR /var/www",
+    "ENV HOSTNAME www.example.com",
+    "VOLUME /test1 /test2",
+    "EXPOSE 80 443",
+    "LABEL version=1.0",
+    "ONBUILD RUN date",
+    "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
+    "ENTRYPOINT /var/www/start.sh"
+  ]
 }
 ```
 
@@ -345,9 +345,9 @@ of post-processors that are treated as as single pipeline, see
 ```hcl
   post-processors {
     post-processor "docker-import" {
-        repository =  "myrepo/myimage"
-        tag = "0.7"
-      }
+      repository =  "myrepo/myimage"
+      tag = "0.7"
+    }
     post-processor "docker-push" {}
   }
 }
@@ -407,9 +407,9 @@ information):
 ```hcl
   post-processors {
     post-processor "docker-tag" {
-        repository =  "myrepo/myimage"
-        tags = ["0.7"]
-      }
+      repository =  "myrepo/myimage"
+      tags = ["0.7"]
+    }
     post-processor "docker-push" {}
   }
 }
@@ -455,16 +455,16 @@ nearly-identical sequence definitions, as demonstrated by the example below:
 ```hcl
   post-processors {
     post-processor "docker-tag" {
-        repository =  "myrepo/myimage1"
-        tags = ["0.7"]
-      }
+      repository =  "myrepo/myimage1"
+      tags = ["0.7"]
+    }
     post-processor "docker-push" {}
   }
   post-processors {
     post-processor "docker-tag" {
-        repository =  "myrepo/myimage2"
-        tags = ["0.7"]
-      }
+      repository =  "myrepo/myimage2"
+      tags = ["0.7"]
+    }
     post-processor "docker-push" {}
   }
 }
@@ -519,10 +519,10 @@ container.
 
 ```hcl
 source "docker" "windows" {
-    image = "microsoft/windowsservercore:1709"
-    container_dir = "c:/app"
-    windows_container = true
-    commit = true
+  image = "microsoft/windowsservercore:1709"
+  container_dir = "c:/app"
+  windows_container = true
+  commit = true
 }
 
 build {
@@ -562,14 +562,14 @@ above and example configuration properties are shown below:
 ```hcl
 post-processors {
   post-processor "docker-tag" {
-      repository = "12345.dkr.ecr.us-east-1.amazonaws.com/packer"
-      tags = ["0.7"]
+    repository = "12345.dkr.ecr.us-east-1.amazonaws.com/packer"
+    tags = ["0.7"]
   }
   post-processor "docker-push" {
-      ecr_login = true
-      aws_access_key = "YOUR KEY HERE"
-      aws_secret_key = "YOUR SECRET KEY HERE"
-      login_server = "12345.dkr.ecr.us-east-1.amazonaws.com"
+    ecr_login = true
+    aws_access_key = "YOUR KEY HERE"
+    aws_secret_key = "YOUR SECRET KEY HERE"
+    login_server = "12345.dkr.ecr.us-east-1.amazonaws.com"
   }
 }
 ```
@@ -612,19 +612,19 @@ and example configuration properties are shown below:
 <Tab heading="HCL2">
 
 ```hcl
-    post-processors {
-        post-processor "docker-tag" {
-            repository = "public.ecr.aws/YOUR REGISTRY ALIAS HERE/YOUR REGISTRY NAME HERE"
-            tags       = ["latest"]
-        }
+post-processors {
+  post-processor "docker-tag" {
+    repository = "public.ecr.aws/YOUR REGISTRY ALIAS HERE/YOUR REGISTRY NAME HERE"
+    tags       = ["latest"]
+  }
 
-        post-processor "docker-push" {
+  post-processor "docker-push" {
     ecr_login = true
     aws_access_key = "YOUR KEY HERE"
     aws_secret_key = "YOUR SECRET KEY HERE"
-            login_server = "public.ecr.aws/YOUR REGISTRY ALIAS HERE"
-        }
-    }
+    login_server = "public.ecr.aws/YOUR REGISTRY ALIAS HERE"
+  }
+}
 ```
 
 </Tab>

--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -526,7 +526,7 @@ source "docker" "windows" {
 }
 
 build {
-  sources = ["source.docker.example"]
+  sources = ["source.docker.windows"]
 }
 ```
 
@@ -619,9 +619,9 @@ and example configuration properties are shown below:
         }
 
         post-processor "docker-push" {
-            "ecr_login": true,
-            "aws_access_key": "YOUR KEY HERE",
-            "aws_secret_key": "YOUR SECRET KEY HERE",
+    ecr_login = true
+    aws_access_key = "YOUR KEY HERE"
+    aws_secret_key = "YOUR SECRET KEY HERE"
             login_server = "public.ecr.aws/YOUR REGISTRY ALIAS HERE"
         }
     }

--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -39,17 +39,6 @@ Below is a fully functioning example. It doesn't do anything useful, since no
 provisioners are defined, but it will effectively repackage an image.
 
 <Tabs>
-<Tab heading="JSON">
-
-```json
-{
-  "type": "docker",
-  "image": "ubuntu",
-  "export_path": "image.tar"
-}
-```
-
-</Tab>
 <Tab heading="HCL2">
 
 ```hcl
@@ -60,6 +49,17 @@ source "docker" "example" {
 
 build {
   sources = ["source.docker.example"]
+}
+```
+
+</Tab>
+<Tab heading="JSON">
+
+```json
+{
+  "type": "docker",
+  "image": "ubuntu",
+  "export_path": "image.tar"
 }
 ```
 
@@ -112,6 +112,27 @@ Example uses of all of the options, assuming one is building an NGINX image
 from ubuntu as an simple example:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "docker" "example" {
+    image = "ubuntu"
+    commit = true
+      changes = [
+      "USER www-data",
+      "WORKDIR /var/www",
+      "ENV HOSTNAME www.example.com",
+      "VOLUME /test1 /test2",
+      "EXPOSE 80 443",
+      "LABEL version=1.0",
+      "ONBUILD RUN date",
+      "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
+      "ENTRYPOINT /var/www/start.sh"
+    ]
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -130,27 +151,6 @@ from ubuntu as an simple example:
     "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
     "ENTRYPOINT /var/www/start.sh"
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "docker" "example" {
-    image = "ubuntu"
-    commit = true
-      changes = [
-      "USER www-data",
-      "WORKDIR /var/www",
-      "ENV HOSTNAME www.example.com",
-      "VOLUME /test1 /test2",
-      "EXPOSE 80 443",
-      "LABEL version=1.0",
-      "ONBUILD RUN date",
-      "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
-      "ENTRYPOINT /var/www/start.sh"
-    ]
 }
 ```
 
@@ -340,6 +340,20 @@ of post-processors that are treated as as single pipeline, see
 [Post-Processors](/packer/docs/templates/legacy_json_templates/post-processors) for more information):
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+  post-processors {
+    post-processor "docker-import" {
+        repository =  "myrepo/myimage"
+        tag = "0.7"
+      }
+    post-processor "docker-push" {}
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -356,20 +370,6 @@ of post-processors that are treated as as single pipeline, see
       }
     ]
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-  post-processors {
-    post-processor "docker-import" {
-        repository =  "myrepo/myimage"
-        tag = "0.7"
-      }
-    post-processor "docker-push" {}
-  }
 }
 ```
 
@@ -402,6 +402,20 @@ pipeline, see [Post-Processors](/packer/docs/templates/legacy_json_templates/pos
 information):
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+  post-processors {
+    post-processor "docker-tag" {
+        repository =  "myrepo/myimage"
+        tags = ["0.7"]
+      }
+    post-processor "docker-push" {}
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -422,20 +436,6 @@ information):
 ```
 
 </Tab>
-<Tab heading="HCL2">
-
-```hcl
-  post-processors {
-    post-processor "docker-tag" {
-        repository =  "myrepo/myimage"
-        tags = ["0.7"]
-      }
-    post-processor "docker-push" {}
-  }
-}
-```
-
-</Tab>
 </Tabs>
 
 In the above example, the result of each builder is passed through the defined
@@ -450,6 +450,27 @@ container repositories, this could be accomplished by defining two,
 nearly-identical sequence definitions, as demonstrated by the example below:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+  post-processors {
+    post-processor "docker-tag" {
+        repository =  "myrepo/myimage1"
+        tags = ["0.7"]
+      }
+    post-processor "docker-push" {}
+  }
+  post-processors {
+    post-processor "docker-tag" {
+        repository =  "myrepo/myimage2"
+        tags = ["0.7"]
+      }
+    post-processor "docker-push" {}
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -476,27 +497,6 @@ nearly-identical sequence definitions, as demonstrated by the example below:
 ```
 
 </Tab>
-<Tab heading="HCL2">
-
-```hcl
-  post-processors {
-    post-processor "docker-tag" {
-        repository =  "myrepo/myimage1"
-        tags = ["0.7"]
-      }
-    post-processor "docker-push" {}
-  }
-  post-processors {
-    post-processor "docker-tag" {
-        repository =  "myrepo/myimage2"
-        tags = ["0.7"]
-      }
-    post-processor "docker-push" {}
-  }
-}
-```
-
-</Tab>
 </Tabs>
 
 <span id="amazon-ec2-container-registry"></span>
@@ -515,6 +515,22 @@ The following is a fully functional template for building a Windows
 container.
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "docker" "windows" {
+    image = "microsoft/windowsservercore:1709"
+    container_dir = "c:/app"
+    windows_container = true
+    commit = true
+}
+
+build {
+  sources = ["source.docker.example"]
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -528,22 +544,6 @@ container.
       "commit": true
     }
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "docker" "windows" {
-    image = "microsoft/windowsservercore:1709"
-    container_dir = "c:/app"
-    windows_container = true
-    commit = true
-}
-
-build {
-  sources = ["source.docker.example"]
 }
 ```
 
@@ -609,6 +609,25 @@ Gallery](https://gallery.ecr.aws/). The post processors work as described above
 and example configuration properties are shown below:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+    post-processors {
+        post-processor "docker-tag" {
+            repository = "public.ecr.aws/YOUR REGISTRY ALIAS HERE/YOUR REGISTRY NAME HERE"
+            tags       = ["latest"]
+        }
+
+        post-processor "docker-push" {
+            "ecr_login": true,
+            "aws_access_key": "YOUR KEY HERE",
+            "aws_secret_key": "YOUR SECRET KEY HERE",
+            login_server = "public.ecr.aws/YOUR REGISTRY ALIAS HERE"
+        }
+    }
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -629,25 +648,6 @@ and example configuration properties are shown below:
                 }
             ]
         ]
-    }
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-    post-processors {
-        post-processor "docker-tag" {
-            repository = "public.ecr.aws/YOUR REGISTRY ALIAS HERE/YOUR REGISTRY NAME HERE"
-            tags       = ["latest"]
-        }
-
-        post-processor "docker-push" {
-            "ecr_login": true,
-            "aws_access_key": "YOUR KEY HERE",
-            "aws_secret_key": "YOUR SECRET KEY HERE",
-            login_server = "public.ecr.aws/YOUR REGISTRY ALIAS HERE"
-        }
     }
 ```
 

--- a/docs/post-processors/docker-import.mdx
+++ b/docs/post-processors/docker-import.mdx
@@ -22,6 +22,27 @@ registry.
 ## Basic Example
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "docker" "example" {
+    image = "ubuntu:18.04"
+    export_path = "party_parrot.tar"
+}
+
+build {
+  sources = [
+    "source.docker.example"
+  ]
+
+  post-processor "docker-import" {
+    repository = "local/ubuntu"
+    tag = "latest"
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -40,27 +61,6 @@ registry.
       "tag": "latest"
     }
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "docker" "example" {
-    image = "ubuntu:18.04"
-    export_path = "party_parrot.tar"
-}
-
-build {
-  sources = [
-    "source.docker.example"
-  ]
-
-  post-processor "docker-import" {
-    repository = "local/ubuntu"
-    tag = "latest"
-  }
 }
 ```
 
@@ -95,6 +95,16 @@ is optional.
 An example is shown below, showing only the post-processor configuration:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processor "docker-import" {
+  repository = "hashicorp/packer"
+  tag = "0.7"
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -102,16 +112,6 @@ An example is shown below, showing only the post-processor configuration:
   "type": "docker-import",
   "repository": "hashicorp/packer",
   "tag": "0.7"
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-post-processor "docker-import" {
-  repository = "hashicorp/packer"
-  tag = "0.7"
 }
 ```
 
@@ -137,6 +137,27 @@ Example uses of all of the options, assuming one is building an NGINX image
 from ubuntu as an simple example:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processor "docker-import" {
+  repository = "local/centos6"
+  tag = "latest"
+  changes = [
+    "USER www-data",
+    "WORKDIR /var/www",
+    "ENV HOSTNAME www.example.com",
+    "VOLUME /test1 /test2",
+    "EXPOSE 80 443",
+    "LABEL version=1.0",
+    "ONBUILD RUN date",
+    "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
+    "ENTRYPOINT /var/www/start.sh",
+  ]
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -154,27 +175,6 @@ from ubuntu as an simple example:
     "ONBUILD RUN date",
     "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
     "ENTRYPOINT /var/www/start.sh"
-  ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-post-processor "docker-import" {
-  repository = "local/centos6"
-  tag = "latest"
-  changes = [
-    "USER www-data",
-    "WORKDIR /var/www",
-    "ENV HOSTNAME www.example.com",
-    "VOLUME /test1 /test2",
-    "EXPOSE 80 443",
-    "LABEL version=1.0",
-    "ONBUILD RUN date",
-    "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
-    "ENTRYPOINT /var/www/start.sh",
   ]
 }
 ```

--- a/docs/post-processors/docker-import.mdx
+++ b/docs/post-processors/docker-import.mdx
@@ -26,8 +26,8 @@ registry.
 
 ```hcl
 source "docker" "example" {
-    image = "ubuntu:18.04"
-    export_path = "party_parrot.tar"
+  image = "ubuntu:18.04"
+  export_path = "party_parrot.tar"
 }
 
 build {

--- a/docs/post-processors/docker-save.mdx
+++ b/docs/post-processors/docker-save.mdx
@@ -43,21 +43,20 @@ The configuration for this post-processor only requires one option.
 An example is shown below, showing only the post-processor configuration:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processor "docker-save" {
+  path = "foo.tar"
+}
+```
+</Tab>
 <Tab heading="JSON">
 
 ```json
 {
   "type": "docker-save",
   "path": "foo.tar"
-}
-```
-</Tab>
-
-<Tab heading="HCL2">
-
-```hcl
-post-processor "docker-save" {
-  path = "foo.tar"
 }
 ```
 </Tab>

--- a/docs/post-processors/docker-tag.mdx
+++ b/docs/post-processors/docker-tag.mdx
@@ -50,6 +50,15 @@ settings are optional.
 An example is shown below, showing only the post-processor configuration:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processor "docker-tag" {
+  repository = "hashicorp/packer"
+  tags = ["0.7", "anothertag"]
+}
+```
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -57,16 +66,6 @@ An example is shown below, showing only the post-processor configuration:
   "type": "docker-tag",
   "repository": "hashicorp/packer",
   "tags": ["0.7", "anothertag"]
-}
-```
-</Tab>
-
-<Tab heading="HCL2">
-
-```hcl
-post-processor "docker-tag" {
-  repository = "hashicorp/packer"
-  tags = ["0.7", "anothertag"]
 }
 ```
 </Tab>


### PR DESCRIPTION
Swaps order of HCL2/JSON example code tabs so that the HCL2 tab is the default

Ran `make generate` after committing changes, which did not result in a diff, so I believe this should be sufficient.

Note: The diff looks weird because git diff is getting confused by the similar blocks of code. For easier reading, I split the changes into two commits where the swaps aren't being confused by git diff. 