### PR TITLE
feat: use CMD/ENTRYPOINT from source image by default

### DIFF
--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -6,7 +6,6 @@ package docker
 import (
 	"context"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -52,27 +51,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 	log.Printf("[DEBUG] Docker version: %s", version.String())
 
-	// Fetch default CMD and ENTRYPOINT
-	defaultCmd, _ := driver.Cmd(b.config.Image)
-	defaultEntrypoint, _ := driver.Entrypoint(b.config.Image)
-
-	// Set defaults if not provided by the user
-	hasCmd, hasEntrypoint := false, false
-	for _, change := range b.config.Changes {
-		if strings.HasPrefix(change, "CMD") {
-			hasCmd = true
-		} else if strings.HasPrefix(change, "ENTRYPOINT") {
-			hasEntrypoint = true
-		}
-	}
-
-	if !hasCmd && defaultCmd != "" {
-		b.config.Changes = append(b.config.Changes, "CMD "+defaultCmd)
-	}
-	if !hasEntrypoint && defaultEntrypoint != "" {
-		b.config.Changes = append(b.config.Changes, "ENTRYPOINT "+defaultEntrypoint)
-	}
-
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
@@ -111,6 +89,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		log.Print("[DEBUG] Container will be discarded")
 	} else if b.config.Commit {
 		log.Print("[DEBUG] Container will be committed")
+		steps = append(steps, &StepSetDefaults{})
 		steps = append(steps, &StepCommit{
 			GeneratedData: generatedData,
 		})

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -6,7 +6,7 @@ package docker
 import (
 	"context"
 	"log"
-        "strings"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -220,7 +220,7 @@ func (d *DockerDriver) Cmd(id string) (string, error) {
 		"docker",
 		"inspect",
 		"--format",
-		"{{json .Config.Cmd }}",
+		"{{if .Config.Cmd}} {{json .Config.Cmd}} {{else}} [] {{end}}",
 		id)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -237,7 +237,7 @@ func (d *DockerDriver) Entrypoint(id string) (string, error) {
 		"docker",
 		"inspect",
 		"--format",
-		"{{json .Config.Entrypoint }}",
+		"{{if .Config.Entrypoint}} {{json .Config.Entrypoint}} {{else}} [] {{end}}",
 		id)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -214,6 +214,40 @@ func (d *DockerDriver) Digest(id string) (string, error) {
 	return strings.TrimSpace(stdout.String()), nil
 }
 
+func (d *DockerDriver) Cmd(id string) (string, error) {
+	var stderr, stdout bytes.Buffer
+	cmd := exec.Command(
+		"docker",
+		"inspect",
+		"--format",
+		"{{json .Config.Cmd }}",
+		id)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("Error: %s\n\nStderr: %s", err, stderr.String())
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func (d *DockerDriver) Entrypoint(id string) (string, error) {
+	var stderr, stdout bytes.Buffer
+	cmd := exec.Command(
+		"docker",
+		"inspect",
+		"--format",
+		"{{json .Config.Entrypoint }}",
+		id)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("Error: %s\n\nStderr: %s", err, stderr.String())
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
 func (d *DockerDriver) Login(repo, user, pass string) error {
 	d.l.Lock()
 

--- a/builder/docker/step_set_defaults.go
+++ b/builder/docker/step_set_defaults.go
@@ -1,0 +1,39 @@
+package docker
+
+import (
+	"context"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"strings"
+)
+
+type StepSetDefaults struct{}
+
+func (s *StepSetDefaults) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(*DockerDriver)
+	config := state.Get("config").(*Config)
+
+	// Fetch default CMD and ENTRYPOINT
+	defaultCmd, _ := driver.Cmd(config.Image)
+	defaultEntrypoint, _ := driver.Entrypoint(config.Image)
+
+	// Set defaults if not provided by the user
+	hasCmd, hasEntrypoint := false, false
+	for _, change := range config.Changes {
+		if strings.HasPrefix(change, "CMD") {
+			hasCmd = true
+		} else if strings.HasPrefix(change, "ENTRYPOINT") {
+			hasEntrypoint = true
+		}
+	}
+
+	if !hasCmd && defaultCmd != "" {
+		config.Changes = append(config.Changes, "CMD "+defaultCmd)
+	}
+	if !hasEntrypoint && defaultEntrypoint != "" {
+		config.Changes = append(config.Changes, "ENTRYPOINT "+defaultEntrypoint)
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepSetDefaults) Cleanup(state multistep.StateBag) {}

--- a/builder/docker/step_set_defaults.go
+++ b/builder/docker/step_set_defaults.go
@@ -2,8 +2,9 @@ package docker
 
 import (
 	"context"
-	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"strings"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
 )
 
 type StepSetDefaults struct{}


### PR DESCRIPTION
With this change the images built will by default get the CMD and ENTRYPOINT from the source image if not overwritten by a user in the `changes` configuration option.
This replicates the behavior when building images from a Dockerfile.

I found numerous complaints which all seem to be related to the behaviour of the docker builder overwriting the CMD / ENTRYPOINT which this change should solve. (Kind of surprising to see that this hasn't been fixed yet 😵‍)

Closes #158
Closes #132
Closes #13 
Closes #9
Closes https://github.com/hashicorp/packer/issues/4914

