### PR TITLE
docs: mark plugin as hcp ready

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -7,6 +7,7 @@ integration {
   name = "Docker"
   description = "The docker plugin can be used with HashiCorp Packer to manage containers with Docker."
   identifier = "packer/hashicorp/docker"
+  flags = ["hcp-ready"]
   component {
     type = "builder"
     name = "Docker"


### PR DESCRIPTION
Since the plugin supports HCP Packer, we should tag it as such.