### PR TITLE
use private URLs in EC2 registry post processors HCL example

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -543,15 +543,15 @@ above and example configuration properties are shown below:
 ```hcl
 post-processors {
   post-processor "docker-tag" {
-    repository = "public.ecr.aws/YOUR REGISTRY ALIAS HERE/YOUR REGISTRY NAME HERE"
-    tags       = ["latest"]
+    repository =  "12345.dkr.ecr.us-east-1.amazonaws.com/packer"
+    tags       = ["0.7"]
   }
 
   post-processor "docker-push" {
     ecr_login = true
     aws_access_key = "YOUR KEY HERE"
     aws_secret_key = "YOUR SECRET KEY HERE"
-    login_server = "public.ecr.aws/YOUR REGISTRY ALIAS HERE"
+    login_server = "https://12345.dkr.ecr.us-east-1.amazonaws.com/"
   }
 }
 ```


### PR DESCRIPTION
Context
=======
The post processors examples in the **Amazon EC2 Container Registry** section are inconsisent:  

- The JSON example uses a private registry URL: 12345.dkr.ecr.us-east-1.amazonaws.com/packer
- The HCL2 uses a public URL: public.ecr.aws/YOUR REGISTRY ALIAS HERE/YOUR REGISTRY NAME HERE 

Changes
========
Update the URLs in the HCL2 example to match the JSON example

