### PR TITLE
builder: force an empty cmd/entrypoint if unset

### DIFF
--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -220,7 +220,7 @@ func (d *DockerDriver) Cmd(id string) (string, error) {
 		"docker",
 		"inspect",
 		"--format",
-		"{{if .Config.Cmd}} {{json .Config.Cmd}} {{else}} [] {{end}}",
+		"{{if .Config.Cmd}} {{json .Config.Cmd}} {{else}} [\"\"] {{end}}",
 		id)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -237,7 +237,7 @@ func (d *DockerDriver) Entrypoint(id string) (string, error) {
 		"docker",
 		"inspect",
 		"--format",
-		"{{if .Config.Entrypoint}} {{json .Config.Entrypoint}} {{else}} [] {{end}}",
+		"{{if .Config.Entrypoint}} {{json .Config.Entrypoint}} {{else}} [\"\"] {{end}}",
 		id)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/builder/docker/step_set_defaults.go
+++ b/builder/docker/step_set_defaults.go
@@ -17,6 +17,19 @@ func (s *StepSetDefaults) Run(ctx context.Context, state multistep.StateBag) mul
 	config := state.Get("config").(*Config)
 
 	// Fetch default CMD and ENTRYPOINT
+	//
+	// NOTE: if they're empty, the returned value is expected to be [""]
+	// This is because in order to override what we had set when running
+	// the build container, they need to be an array with nothing in it.
+	// The commit command treats explicit `null` as a NOOP, same with `[]`.
+	// If a string is passed as the change argument, it will be appended to
+	// what already exists for the cmd/entrypoint, which doesn't match the
+	// need here, as we need to forcefully set what was originally
+	// specified.
+	//
+	// So while not necessarily clean, the best way to force a similar
+	// behaviour as the original image, we default on an array with an
+	// empty string as argument, which is effectively the same as `null`.
 	defaultCmd, _ := driver.Cmd(config.Image)
 	defaultEntrypoint, _ := driver.Entrypoint(config.Image)
 
@@ -30,10 +43,10 @@ func (s *StepSetDefaults) Run(ctx context.Context, state multistep.StateBag) mul
 		}
 	}
 
-	if !hasCmd && defaultCmd != "" {
+	if !hasCmd {
 		config.Changes = append(config.Changes, "CMD "+defaultCmd)
 	}
-	if !hasEntrypoint && defaultEntrypoint != "" {
+	if !hasEntrypoint {
 		config.Changes = append(config.Changes, "ENTRYPOINT "+defaultEntrypoint)
 	}
 


### PR DESCRIPTION
The code to set the default values for cmd/entrypoint in order to inherit what was set from the original image was working well if both the cmd and entrypoint were set, but if the entrypoint was null, the resulting image would inherit the temporary container's, which was /bin/sh.

This resulted in some images being built incorrectly, with `/bin/sh` as entrypoint, regardless of what we had as CMD/ENTRYPOINT in this case.

To fix this issue, we return a JSON array with an empty string if the entrypoint or the CMD was null in the image, and we haven't decided to override it.

This effectively forces the resulting image to have an equivalent of null as the CMD/ENTRYPOINT, which makes the final image honour the behaviour from the source image.

Closes #176 

cc: @gardar for insights, as you had submitted the implementation originally, this fixes the case where there's some `null` in the base image, please refer to the linked issue for a summary of the problem, if you have suggestions regarding my code please feel free to share!

