### PR TITLE
chore: update `version.go`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,15 +6,8 @@ package version
 import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
-	// Version is the main version number that is being run at the moment.
-	Version = "1.0.11"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	Version           = "1.0.11"
 	VersionPrerelease = "dev"
-
-	// PluginVersion is used by the plugin set to allow Packer to recognize
-	// what version this plugin is.
-	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+	VersionMetadata   = ""
+	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)
 )


### PR DESCRIPTION
### Summary

- Replaces the deprecated `InitializePluginVersion` with `NewPluginVersion` from `packer-plugin-sdk`, which is the recommended approach in `version/version.go`.
- Removed superfluous comments that are already included in the SDK.
