### PR TITLE
Alt executable support

### DIFF
--- a/.web-docs/components/builder/docker/README.md
+++ b/.web-docs/components/builder/docker/README.md
@@ -229,6 +229,16 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
   capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
   to drop from the container.
 
+- `docker_path` (string) - Sets the docker binary to use for running commands.
+  
+  If you want to use a specific version of the docker binary, or a
+  docker alternative for building your container, you can specify this
+  through this option.
+  **Note**: if using an alternative like `podman`, not all options are
+  equivalent, and the build may fail in this case.
+  
+  Defaults to "docker"
+
 - `exec_user` (string) - Username (UID) to run remote commands with. You can also set the group
   name/ID if you want: (UID or UID:GID). You may need this if you get
   permission errors trying to run the shell or other provisioners.

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -40,7 +40,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 }
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook) (packersdk.Artifact, error) {
-	driver := &DockerDriver{Ctx: &b.config.ctx, Ui: ui}
+	driver := &DockerDriver{
+		Executable: b.config.Executable,
+		Ctx:        &b.config.ctx,
+		Ui:         ui,
+	}
 	if err := driver.Verify(); err != nil {
 		return nil, err
 	}

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -67,6 +67,16 @@ type Config struct {
 	// capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
 	// to drop from the container.
 	CapDrop []string `mapstructure:"cap_drop" required:"false"`
+	// Sets the docker binary to use for running commands.
+	//
+	// If you want to use a specific version of the docker binary, or a
+	// docker alternative for building your container, you can specify this
+	// through this option.
+	// **Note**: if using an alternative like `podman`, not all options are
+	// equivalent, and the build may fail in this case.
+	//
+	// Defaults to "docker"
+	Executable string `mapstructure:"docker_path"`
 	// Username (UID) to run remote commands with. You can also set the group
 	// name/ID if you want: (UID or UID:GID). You may need this if you get
 	// permission errors trying to run the shell or other provisioners.
@@ -178,6 +188,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		if c.WindowsContainer {
 			c.RunCommand = []string{"-d", "-i", "-t", "--entrypoint=powershell", "--", "{{.Image}}"}
 		}
+	}
+
+	if c.Executable == "" {
+		c.Executable = "docker"
 	}
 
 	// Default to the normal Docker type

--- a/builder/docker/config.hcl2spec.go
+++ b/builder/docker/config.hcl2spec.go
@@ -107,6 +107,7 @@ type FlatConfig struct {
 	Discard                   *bool                          `mapstructure:"discard" required:"true" cty:"discard" hcl:"discard"`
 	CapAdd                    []string                       `mapstructure:"cap_add" required:"false" cty:"cap_add" hcl:"cap_add"`
 	CapDrop                   []string                       `mapstructure:"cap_drop" required:"false" cty:"cap_drop" hcl:"cap_drop"`
+	Executable                *string                        `mapstructure:"docker_path" cty:"docker_path" hcl:"docker_path"`
 	ExecUser                  *string                        `mapstructure:"exec_user" required:"false" cty:"exec_user" hcl:"exec_user"`
 	ExportPath                *string                        `mapstructure:"export_path" required:"true" cty:"export_path" hcl:"export_path"`
 	Image                     *string                        `mapstructure:"image" required:"false" cty:"image" hcl:"image"`
@@ -211,6 +212,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"discard":                      &hcldec.AttrSpec{Name: "discard", Type: cty.Bool, Required: false},
 		"cap_add":                      &hcldec.AttrSpec{Name: "cap_add", Type: cty.List(cty.String), Required: false},
 		"cap_drop":                     &hcldec.AttrSpec{Name: "cap_drop", Type: cty.List(cty.String), Required: false},
+		"docker_path":                  &hcldec.AttrSpec{Name: "docker_path", Type: cty.String, Required: false},
 		"exec_user":                    &hcldec.AttrSpec{Name: "exec_user", Type: cty.String, Required: false},
 		"export_path":                  &hcldec.AttrSpec{Name: "export_path", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},

--- a/builder/docker/step_connect_docker.go
+++ b/builder/docker/step_connect_docker.go
@@ -33,7 +33,7 @@ func (s *StepConnectDocker) Run(ctx context.Context, state multistep.StateBag) m
 		return multistep.ActionHalt
 	}
 
-	containerUser, err := getContainerUser(containerId)
+	containerUser, err := getContainerUser(config.Executable, containerId)
 	if err != nil {
 		state.Put("error", err)
 		return multistep.ActionHalt
@@ -43,6 +43,7 @@ func (s *StepConnectDocker) Run(ctx context.Context, state multistep.StateBag) m
 	// os/exec tricks.
 	if config.WindowsContainer {
 		comm := &WindowsContainerCommunicator{Communicator{
+			Executable:    config.Executable,
 			ContainerID:   containerId,
 			HostDir:       tempDir,
 			ContainerDir:  config.ContainerDir,
@@ -56,6 +57,7 @@ func (s *StepConnectDocker) Run(ctx context.Context, state multistep.StateBag) m
 
 	} else {
 		comm := &Communicator{
+			Executable:    config.Executable,
 			ContainerID:   containerId,
 			HostDir:       tempDir,
 			ContainerDir:  config.ContainerDir,
@@ -71,8 +73,8 @@ func (s *StepConnectDocker) Run(ctx context.Context, state multistep.StateBag) m
 
 func (s *StepConnectDocker) Cleanup(state multistep.StateBag) {}
 
-func getContainerUser(containerId string) (string, error) {
-	inspectArgs := []string{"docker", "inspect", "--format", "{{.Config.User}}", containerId}
+func getContainerUser(executable, containerId string) (string, error) {
+	inspectArgs := []string{executable, "inspect", "--format", "{{.Config.User}}", containerId}
 	stdout, err := exec.Command(inspectArgs[0], inspectArgs[1:]...).Output()
 	if err != nil {
 		errStr := fmt.Sprintf("Failed to inspect the container: %s", err)

--- a/docs-partials/builder/docker/Config-not-required.mdx
+++ b/docs-partials/builder/docker/Config-not-required.mdx
@@ -31,6 +31,16 @@
   capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
   to drop from the container.
 
+- `docker_path` (string) - Sets the docker binary to use for running commands.
+  
+  If you want to use a specific version of the docker binary, or a
+  docker alternative for building your container, you can specify this
+  through this option.
+  **Note**: if using an alternative like `podman`, not all options are
+  equivalent, and the build may fail in this case.
+  
+  Defaults to "docker"
+
 - `exec_user` (string) - Username (UID) to run remote commands with. You can also set the group
   name/ID if you want: (UID or UID:GID). You may need this if you get
   permission errors trying to run the shell or other provisioners.

--- a/post-processor/docker-import/post-processor.go
+++ b/post-processor/docker-import/post-processor.go
@@ -22,6 +22,7 @@ const BuilderId = "packer.post-processor.docker-import"
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
+	Executable string   `mapstructure:"docker_path"`
 	Repository string   `mapstructure:"repository"`
 	Tag        string   `mapstructure:"tag"`
 	Changes    []string `mapstructure:"changes"`
@@ -49,6 +50,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		return err
 	}
 
+	if p.config.Executable == "" {
+		p.config.Executable = "docker"
+	}
+
 	return nil
 
 }
@@ -73,7 +78,11 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		importRepo += ":" + p.config.Tag
 	}
 
-	driver := &docker.DockerDriver{Ctx: &p.config.ctx, Ui: ui}
+	driver := &docker.DockerDriver{
+		Executable: p.config.Executable,
+		Ctx:        &p.config.ctx,
+		Ui:         ui,
+	}
 
 	ui.Message("Importing image: " + artifact.Id())
 	ui.Message("Repository: " + importRepo)

--- a/post-processor/docker-import/post-processor.hcl2spec.go
+++ b/post-processor/docker-import/post-processor.hcl2spec.go
@@ -18,6 +18,7 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	Executable          *string           `mapstructure:"docker_path" cty:"docker_path" hcl:"docker_path"`
 	Repository          *string           `mapstructure:"repository" cty:"repository" hcl:"repository"`
 	Tag                 *string           `mapstructure:"tag" cty:"tag" hcl:"tag"`
 	Changes             []string          `mapstructure:"changes" cty:"changes" hcl:"changes"`
@@ -44,6 +45,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"docker_path":                &hcldec.AttrSpec{Name: "docker_path", Type: cty.String, Required: false},
 		"repository":                 &hcldec.AttrSpec{Name: "repository", Type: cty.String, Required: false},
 		"tag":                        &hcldec.AttrSpec{Name: "tag", Type: cty.String, Required: false},
 		"changes":                    &hcldec.AttrSpec{Name: "changes", Type: cty.List(cty.String), Required: false},

--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -25,6 +25,7 @@ const BuilderIdImport = "packer.post-processor.docker-import"
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
+	Executable             string `mapstructure:"docker_path"`
 	Login                  bool
 	LoginUsername          string `mapstructure:"login_username"`
 	LoginPassword          string `mapstructure:"login_password"`
@@ -55,6 +56,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}, raws...)
 	if err != nil {
 		return err
+	}
+
+	if p.config.Executable == "" {
+		p.config.Executable = "docker"
 	}
 
 	if p.config.EcrLogin && p.config.LoginServer == "" {
@@ -96,9 +101,10 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 
 		// If no driver is set, then we use the real driver
 		driver = &docker.DockerDriver{
-			Ctx:       &p.config.ctx,
-			Ui:        ui,
-			ConfigDir: configDir,
+			Executable: p.config.Executable,
+			Ctx:        &p.config.ctx,
+			Ui:         ui,
+			ConfigDir:  configDir,
 		}
 	}
 

--- a/post-processor/docker-push/post-processor.hcl2spec.go
+++ b/post-processor/docker-push/post-processor.hcl2spec.go
@@ -18,6 +18,7 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	Executable          *string           `mapstructure:"docker_path" cty:"docker_path" hcl:"docker_path"`
 	Login               *bool             `cty:"login" hcl:"login"`
 	LoginUsername       *string           `mapstructure:"login_username" cty:"login_username" hcl:"login_username"`
 	LoginPassword       *string           `mapstructure:"login_password" cty:"login_password" hcl:"login_password"`
@@ -51,6 +52,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"docker_path":                &hcldec.AttrSpec{Name: "docker_path", Type: cty.String, Required: false},
 		"login":                      &hcldec.AttrSpec{Name: "login", Type: cty.Bool, Required: false},
 		"login_username":             &hcldec.AttrSpec{Name: "login_username", Type: cty.String, Required: false},
 		"login_password":             &hcldec.AttrSpec{Name: "login_password", Type: cty.String, Required: false},

--- a/post-processor/docker-save/post-processor.go
+++ b/post-processor/docker-save/post-processor.go
@@ -25,7 +25,8 @@ const BuilderId = "packer.post-processor.docker-save"
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	Path string `mapstructure:"path"`
+	Executable string `mapstructure:"docker_path"`
+	Path       string `mapstructure:"path"`
 
 	ctx interpolate.Context
 }
@@ -49,6 +50,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}, raws...)
 	if err != nil {
 		return err
+	}
+
+	if p.config.Executable == "" {
+		p.config.Executable = "docker"
 	}
 
 	return nil
@@ -76,7 +81,11 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	driver := p.Driver
 	if driver == nil {
 		// If no driver is set, then we use the real driver
-		driver = &docker.DockerDriver{Ctx: &p.config.ctx, Ui: ui}
+		driver = &docker.DockerDriver{
+			Executable: p.config.Executable,
+			Ctx:        &p.config.ctx,
+			Ui:         ui,
+		}
 	}
 
 	ui.Message("Saving image: " + artifact.Id())

--- a/post-processor/docker-save/post-processor.hcl2spec.go
+++ b/post-processor/docker-save/post-processor.hcl2spec.go
@@ -18,6 +18,7 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	Executable          *string           `mapstructure:"docker_path" cty:"docker_path" hcl:"docker_path"`
 	Path                *string           `mapstructure:"path" cty:"path" hcl:"path"`
 }
 
@@ -41,6 +42,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"docker_path":                &hcldec.AttrSpec{Name: "docker_path", Type: cty.String, Required: false},
 		"path":                       &hcldec.AttrSpec{Name: "path", Type: cty.String, Required: false},
 	}
 	return s

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -23,6 +23,7 @@ const BuilderId = "packer.post-processor.docker-tag"
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
+	Executable string `mapstructure:"docker_path"`
 	Repository string `mapstructure:"repository"`
 	// Kept for backwards compatibility
 	Tag   []string `mapstructure:"tag"`
@@ -59,6 +60,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 	p.config.Tags = allTags
 
+	if p.config.Executable == "" {
+		p.config.Executable = "docker"
+	}
+
 	return nil
 
 }
@@ -81,7 +86,11 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	driver := p.Driver
 	if driver == nil {
 		// If no driver is set, then we use the real driver
-		driver = &docker.DockerDriver{Ctx: &p.config.ctx, Ui: ui}
+		driver = &docker.DockerDriver{
+			Executable: p.config.Executable,
+			Ctx:        &p.config.ctx,
+			Ui:         ui,
+		}
 	}
 
 	importRepo := p.config.Repository

--- a/post-processor/docker-tag/post-processor.hcl2spec.go
+++ b/post-processor/docker-tag/post-processor.hcl2spec.go
@@ -18,6 +18,7 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	Executable          *string           `mapstructure:"docker_path" cty:"docker_path" hcl:"docker_path"`
 	Repository          *string           `mapstructure:"repository" cty:"repository" hcl:"repository"`
 	Tag                 []string          `mapstructure:"tag" cty:"tag" hcl:"tag"`
 	Tags                []string          `mapstructure:"tags" cty:"tags" hcl:"tags"`
@@ -44,6 +45,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"docker_path":                &hcldec.AttrSpec{Name: "docker_path", Type: cty.String, Required: false},
 		"repository":                 &hcldec.AttrSpec{Name: "repository", Type: cty.String, Required: false},
 		"tag":                        &hcldec.AttrSpec{Name: "tag", Type: cty.List(cty.String), Required: false},
 		"tags":                       &hcldec.AttrSpec{Name: "tags", Type: cty.List(cty.String), Required: false},


### PR DESCRIPTION
When using the builder to create a new container image, we used to default on using the `docker` command for everything.

While this is simple, this can limit what users try to do with the plugin, typically if they need to run their builds on a specific version of Docker which they built from scratch and won't install it, or if they want to build with a Docker-compatible alternative like `podman`.

To circumvent this limitation, we add a new `docker_path` option to the builder, so they can use this to use alternative docker binaries for orchestrating their builds with.