### PR TITLE
Fix: Update docker.mdx

### DIFF
--- a/.web-docs/components/builder/docker/README.md
+++ b/.web-docs/components/builder/docker/README.md
@@ -32,6 +32,11 @@ source "docker" "example" {
   export_path = "image.tar"
 }
 
+build {
+  sources = ["source.docker.example"]
+}
+```
+
 **JSON**
 
 ```json
@@ -39,11 +44,6 @@ source "docker" "example" {
   "type": "docker",
   "image": "ubuntu",
   "export_path": "image.tar"
-}
-```
-
-build {
-  sources = ["source.docker.example"]
 }
 ```
 

--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -43,6 +43,11 @@ source "docker" "example" {
   export_path = "image.tar"
 }
 
+build {
+  sources = ["source.docker.example"]
+}
+```
+
 **JSON**
 
 ```json
@@ -50,11 +55,6 @@ source "docker" "example" {
   "type": "docker",
   "image": "ubuntu",
   "export_path": "image.tar"
-}
-```
-
-build {
-  sources = ["source.docker.example"]
 }
 ```
 


### PR DESCRIPTION
Minor fix to code block '```' guards.

It looks like the `**JSON**` bits were put in by a git merge or something because they were right in the middle of the `hcl` example.