### PR TITLE
Adds initial support for build.arguments

### DIFF
--- a/.web-docs/components/builder/docker/README.md
+++ b/.web-docs/components/builder/docker/README.md
@@ -390,6 +390,9 @@ source "docker" "example" {
   
   Defaults to the directory from which we invoke packer.
 
+- `arguments` (map[string]string) - A mapping of additional build args to provide. The key of
+  the object is the argument name, the value is the argument value.
+
 - `pull` (boolean) - Pull the image when building the base docker image.
   
   Note: defaults to true, to disable this, explicitly set it to false.

--- a/builder/docker/dockerfile_config.go
+++ b/builder/docker/dockerfile_config.go
@@ -99,11 +99,9 @@ func (c DockerfileBootstrapConfig) BuildArgs() []string {
 	}
 
 	// Loops through map of build arguments to add to build command
-	if len(c.Arguments) > 0 {
-		for key, value := range c.Arguments {
-			arg := key + "=" + value
-			retArgs = append(retArgs, "--build-arg", arg)
-		}
+	for key, value := range c.Arguments {
+		arg := key + "=" + value
+		retArgs = append(retArgs, "--build-arg", arg)
 	}
 
 	return append(retArgs, c.BuildDir)

--- a/builder/docker/dockerfile_config.go
+++ b/builder/docker/dockerfile_config.go
@@ -31,6 +31,11 @@ type DockerfileBootstrapConfig struct {
 	//
 	// Defaults to the directory from which we invoke packer.
 	BuildDir string `mapstructure:"build_dir"`
+
+	// A mapping of additional build args to provide. The key of
+	// the object is the argument name, the value is the argument value.
+	Arguments map[string]string `mapstructure:"arguments" required:"false"`
+
 	// Pull the image when building the base docker image.
 	//
 	// Note: defaults to true, to disable this, explicitly set it to false.
@@ -91,6 +96,14 @@ func (c DockerfileBootstrapConfig) BuildArgs() []string {
 
 	if c.Compress {
 		retArgs = append(retArgs, "--compress")
+	}
+
+	// Loops through map of build arguments to add to build command
+	if len(c.Arguments) > 0 {
+		for key, value := range c.Arguments {
+			arg := key + "=" + value
+			retArgs = append(retArgs, "--build-arg", arg)
+		}
 	}
 
 	return append(retArgs, c.BuildDir)

--- a/builder/docker/dockerfile_config.hcl2spec.go
+++ b/builder/docker/dockerfile_config.hcl2spec.go
@@ -10,10 +10,11 @@ import (
 // FlatDockerfileBootstrapConfig is an auto-generated flat version of DockerfileBootstrapConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatDockerfileBootstrapConfig struct {
-	DockerfilePath *string `mapstructure:"path" required:"true" cty:"path" hcl:"path"`
-	BuildDir       *string `mapstructure:"build_dir" cty:"build_dir" hcl:"build_dir"`
-	Pull           *bool   `mapstructure:"pull" cty:"pull" hcl:"pull"`
-	Compress       *bool   `mapstructure:"compress" cty:"compress" hcl:"compress"`
+	DockerfilePath *string           `mapstructure:"path" required:"true" cty:"path" hcl:"path"`
+	BuildDir       *string           `mapstructure:"build_dir" cty:"build_dir" hcl:"build_dir"`
+	Arguments      map[string]string `mapstructure:"arguments" required:"false" cty:"arguments" hcl:"arguments"`
+	Pull           *bool             `mapstructure:"pull" cty:"pull" hcl:"pull"`
+	Compress       *bool             `mapstructure:"compress" cty:"compress" hcl:"compress"`
 }
 
 // FlatMapstructure returns a new FlatDockerfileBootstrapConfig.
@@ -30,6 +31,7 @@ func (*FlatDockerfileBootstrapConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"path":      &hcldec.AttrSpec{Name: "path", Type: cty.String, Required: false},
 		"build_dir": &hcldec.AttrSpec{Name: "build_dir", Type: cty.String, Required: false},
+		"arguments": &hcldec.AttrSpec{Name: "arguments", Type: cty.Map(cty.String), Required: false},
 		"pull":      &hcldec.AttrSpec{Name: "pull", Type: cty.Bool, Required: false},
 		"compress":  &hcldec.AttrSpec{Name: "compress", Type: cty.Bool, Required: false},
 	}

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -45,6 +45,7 @@ func (d *DockerDriver) Build(args []string) (string, error) {
 	imageIdFilePath := imageIdFile.Name()
 	imageIdFile.Close()
 
+	log.Printf("Building container with args: %v", args)
 	cmd := exec.Command(d.Executable, "build")
 	cmd.Args = append(cmd.Args, "--iidfile", imageIdFilePath)
 	cmd.Args = append(cmd.Args, args...)

--- a/docs-partials/builder/docker/DockerfileBootstrapConfig-not-required.mdx
+++ b/docs-partials/builder/docker/DockerfileBootstrapConfig-not-required.mdx
@@ -4,6 +4,9 @@
   
   Defaults to the directory from which we invoke packer.
 
+- `arguments` (map[string]string) - A mapping of additional build args to provide. The key of
+  the object is the argument name, the value is the argument value.
+
 - `pull` (boolean) - Pull the image when building the base docker image.
   
   Note: defaults to true, to disable this, explicitly set it to false.


### PR DESCRIPTION
This PR adds support under the `build` section to specify the `arguments` value when bootstrapping a packer build using a Dockerfile.  More specifically, when specifying an optional `build.arguments` value, which must be a map of key / value pairs corresponding to the name / value of docker ARGs, the plugin will add `--build-arg <key>=<value>` to the arguments passed to `docker build` for each record in the map, allowing the user to specify or override build-time arguments .