### PR TITLE
Adds initial support for login before bootstrapped build step

### DIFF
--- a/.web-docs/components/builder/docker/README.md
+++ b/.web-docs/components/builder/docker/README.md
@@ -298,8 +298,9 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
 
 - `platform` (string) - Set platform if server is multi-platform capable
 
-- `login` (bool) - This is used to login to dockerhub to pull a private base container. For
-  pushing to dockerhub, see the docker post-processors
+- `login` (bool) - This is used to login to a private docker repository (e.g., dockerhub)
+  to build or pull a private base container. For pushing to a private
+   repository, see the docker post-processors.
 
 - `login_password` (string) - The password to use to authenticate to login.
 
@@ -307,11 +308,11 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
 
 - `login_username` (string) - The username to use to authenticate to login.
 
-- `ecr_login` (bool) - Defaults to false. If true, the builder will login in order to pull the
-  image from Amazon EC2 Container Registry (ECR). The builder only logs in
-  for the duration of the pull. If true login_server is required and
-  login, login_username, and login_password will be ignored. For more
-  information see the section on ECR.
+- `ecr_login` (bool) - Defaults to false. If true, the builder will login in order to build or
+  pull the image from Amazon EC2 Container Registry (ECR). The builder
+  only logs in for the duration of the build or pull step. If true,
+  login_server is required and login, login_username, and login_password
+  will be ignored. For more information see the section on ECR.
 
 <!-- End of code generated from the comments of the Config struct in builder/docker/config.go; -->
 

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -142,8 +142,9 @@ type Config struct {
 	// Set platform if server is multi-platform capable
 	Platform string `mapstructure:"platform" required:"false"`
 
-	// This is used to login to dockerhub to pull a private base container. For
-	// pushing to dockerhub, see the docker post-processors
+	// This is used to login to a private docker repository (e.g., dockerhub)
+	// to build or pull a private base container. For pushing to a private
+	//  repository, see the docker post-processors.
 	Login bool `mapstructure:"login" required:"false"`
 	// The password to use to authenticate to login.
 	LoginPassword string `mapstructure:"login_password" required:"false"`
@@ -151,11 +152,11 @@ type Config struct {
 	LoginServer string `mapstructure:"login_server" required:"false"`
 	// The username to use to authenticate to login.
 	LoginUsername string `mapstructure:"login_username" required:"false"`
-	// Defaults to false. If true, the builder will login in order to pull the
-	// image from Amazon EC2 Container Registry (ECR). The builder only logs in
-	// for the duration of the pull. If true login_server is required and
-	// login, login_username, and login_password will be ignored. For more
-	// information see the section on ECR.
+	// Defaults to false. If true, the builder will login in order to build or
+	// pull the image from Amazon EC2 Container Registry (ECR). The builder
+	// only logs in for the duration of the build or pull step. If true,
+	// login_server is required and login, login_username, and login_password
+	// will be ignored. For more information see the section on ECR.
 	EcrLogin        bool `mapstructure:"ecr_login" required:"false"`
 	AwsAccessConfig `mapstructure:",squash"`
 

--- a/builder/docker/step_build.go
+++ b/builder/docker/step_build.go
@@ -2,9 +2,7 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
@@ -22,7 +20,51 @@ func (s *stepBuild) Run(ctx context.Context, state multistep.StateBag) multistep
 
 	ui := state.Get("ui").(packer.Ui)
 	driver := state.Get("driver").(Driver)
+	config, ok := state.Get("config").(*Config)
+	if !ok {
+		err := fmt.Errorf("error encountered obtaining docker config")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
 	ui.Say("Building base image...")
+
+	if config.EcrLogin {
+		ui.Message("Fetching ECR credentials...")
+
+		username, password, err := config.EcrGetLogin(config.LoginServer)
+		if err != nil {
+			err := fmt.Errorf("Error fetching ECR credentials: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		config.LoginUsername = username
+		config.LoginPassword = password
+	}
+
+	if config.Login || config.EcrLogin {
+		ui.Message("Logging in...")
+		err := driver.Login(
+			config.LoginServer,
+			config.LoginUsername,
+			config.LoginPassword)
+		if err != nil {
+			err := fmt.Errorf("Error logging in: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		defer func() {
+			ui.Message("Logging out...")
+			if err := driver.Logout(config.LoginServer); err != nil {
+				ui.Error(fmt.Sprintf("Error logging out: %s", err))
+			}
+		}()
+	}
 
 	imageId, err := driver.Build(s.buildArgs.BuildArgs())
 	if err != nil {
@@ -31,18 +73,6 @@ func (s *stepBuild) Run(ctx context.Context, state multistep.StateBag) multistep
 	}
 
 	ui.Sayf("Finished building base image %q", imageId)
-
-	cfg, ok := state.GetOk("config")
-	if !ok {
-		state.Put("error", errors.New("missing config in state; this is a docker plugin bug, please report upstream"))
-		return multistep.ActionHalt
-	}
-
-	config, ok := cfg.(*Config)
-	if !ok {
-		state.Put("error", fmt.Errorf("config object set but type (%s) doesn't match. This is a docker plugin bug, please report upstream", reflect.TypeOf(cfg).String()))
-		return multistep.ActionHalt
-	}
 
 	config.Image = imageId
 

--- a/docs-partials/builder/docker/Config-not-required.mdx
+++ b/docs-partials/builder/docker/Config-not-required.mdx
@@ -100,8 +100,9 @@
 
 - `platform` (string) - Set platform if server is multi-platform capable
 
-- `login` (bool) - This is used to login to dockerhub to pull a private base container. For
-  pushing to dockerhub, see the docker post-processors
+- `login` (bool) - This is used to login to a private docker repository (e.g., dockerhub)
+  to build or pull a private base container. For pushing to a private
+   repository, see the docker post-processors.
 
 - `login_password` (string) - The password to use to authenticate to login.
 
@@ -109,10 +110,10 @@
 
 - `login_username` (string) - The username to use to authenticate to login.
 
-- `ecr_login` (bool) - Defaults to false. If true, the builder will login in order to pull the
-  image from Amazon EC2 Container Registry (ECR). The builder only logs in
-  for the duration of the pull. If true login_server is required and
-  login, login_username, and login_password will be ignored. For more
-  information see the section on ECR.
+- `ecr_login` (bool) - Defaults to false. If true, the builder will login in order to build or
+  pull the image from Amazon EC2 Container Registry (ECR). The builder
+  only logs in for the duration of the build or pull step. If true,
+  login_server is required and login, login_username, and login_password
+  will be ignored. For more information see the section on ECR.
 
 <!-- End of code generated from the comments of the Config struct in builder/docker/config.go; -->


### PR DESCRIPTION
This PR adds support for performing `docker login` before commencing the build step when bootstrapping a packer build using a Dockerfile. More specifically, these changes add analogous logic to the build step from the pull step to attempt to authenticate with the information specified in the `login_server`, `login_username`, and `login_password` config options when the `login` value is true, or via ECR when the `ecr_login` value is true.  This allows the user to build images from a private docker repository when performing a bootstrapped build from a Dockerfile.

Closes #194 
