### PR TITLE
builder: fix IsDefault with new arguments

### DIFF
--- a/builder/docker/config_test.go
+++ b/builder/docker/config_test.go
@@ -164,6 +164,14 @@ func TestConfigBuildBootstrapConfig(t *testing.T) {
 			true,
 		},
 		{
+			"error - no image, build is default with empty map, config is invalid",
+			map[string]interface{}{
+				"arguments": map[string]string{},
+			},
+			false,
+			true,
+		},
+		{
 			"error - unknown dockerfile path",
 			map[string]interface{}{
 				"path": "./test-fixtures/no_such_dockerfile",

--- a/builder/docker/dockerfile_config.go
+++ b/builder/docker/dockerfile_config.go
@@ -60,6 +60,10 @@ func (c *DockerfileBootstrapConfig) Prepare() ([]string, error) {
 		return nil, nil
 	}
 
+	if c.DockerfilePath == "" {
+		return nil, fmt.Errorf("`path` is required for bootstrapping a build with `docker build`")
+	}
+
 	if c.BuildDir == "" {
 		c.BuildDir = "."
 	}

--- a/builder/docker/dockerfile_config.go
+++ b/builder/docker/dockerfile_config.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
@@ -113,18 +115,14 @@ func (c DockerfileBootstrapConfig) BuildArgs() []string {
 	return append(retArgs, c.BuildDir)
 }
 
+// IsDefault returns whether the DockerfileBootstrapConfig is the empty one or not
 func (c DockerfileBootstrapConfig) IsDefault() bool {
-	if c.BuildDir != "" {
-		return false
+	// We can ignore arguments for the comparison since a map can be either
+	// nil or empty, and should be considered equal in either case.
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(DockerfileBootstrapConfig{}, "Arguments"),
 	}
 
-	if c.Compress {
-		return false
-	}
-
-	if c.DockerfilePath != "" {
-		return false
-	}
-
-	return true
+	return cmp.Equal(c, DockerfileBootstrapConfig{}, cmpOpts...) &&
+		(c.Arguments == nil || len(c.Arguments) == 0)
 }

--- a/builder/docker/dockerfile_config.go
+++ b/builder/docker/dockerfile_config.go
@@ -38,6 +38,7 @@ type DockerfileBootstrapConfig struct {
 	// the object is the argument name, the value is the argument value.
 	Arguments map[string]string `mapstructure:"arguments" required:"false"`
 
+	// Inherited from the global configuration: set platform if server is multi-platform capable
 	Platform string `mapstructure-to-hcl2:",skip"`
 
 	// Pull the image when building the base docker image.

--- a/builder/docker/dockerfile_config_test.go
+++ b/builder/docker/dockerfile_config_test.go
@@ -1,0 +1,59 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
+)
+
+func TestBuildConfigIsDefault(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputConfig   DockerfileBootstrapConfig
+		expectDefault bool
+	}{
+		{
+			"empty config - should be default",
+			DockerfileBootstrapConfig{},
+			true,
+		},
+		{
+			"dockerfile set - should not be default",
+			DockerfileBootstrapConfig{
+				DockerfilePath: "test",
+			},
+			false,
+		},
+		{
+			"pull explicitly set to false - should not be default",
+			DockerfileBootstrapConfig{
+				Pull: config.TriFalse,
+			},
+			false,
+		},
+		{
+			"build dir set - should not be default",
+			DockerfileBootstrapConfig{
+				BuildDir: "dir",
+			},
+			false,
+		},
+		{
+			"empty argument map - should be default",
+			DockerfileBootstrapConfig{
+				Arguments: map[string]string{},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isDefault := tt.inputConfig.IsDefault()
+			if isDefault != tt.expectDefault {
+				t.Errorf("expected isDefault %t is different from reported %t",
+					tt.expectDefault, isDefault)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.0
 
 require (
 	github.com/aws/aws-sdk-go v1.44.114
+	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/aws-sdk-go-base v0.7.1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.6.0


### PR DESCRIPTION
The IsDefault function on DockerfileBootstrapConfig was implemented manually with the few arguments supported initially, but wasn't updated when subsequent attributes were added.

This commit fixes that by changing how IsDefault is implemented by leveraging go-cmp for comparing the data, ignoring the arguments map, so we can compare that with both the empty map and a nil map, so they are considered default in both cases.

Simple equality wouldn't work on the structure because maps within a structure cannot be compared, so using `==` would provoke a compile-time error, which is handled with this approach, while supporting other new arguments out of the box for later changes.