### PR TITLE
Update Windows Docker example with image and  build.source

### DIFF
--- a/docs/builders/docker.mdx
+++ b/docs/builders/docker.mdx
@@ -425,14 +425,14 @@ container.
 
 ```hcl
 source "docker" "windows" {
-    image = "microsoft/windowsservercore:1709"
+    image = "mcr.microsoft.com/windows/servercore:ltsc2022"
     container_dir = "c:/app"
     windows_container = true
     commit = true
 }
 
 build {
-  sources = ["source.docker.example"]
+  sources = ["source.docker.windows"]
 }
 ```
 
@@ -443,7 +443,7 @@ build {
   "builders": [
     {
       "type": "docker",
-      "image": "microsoft/windowsservercore:1709",
+      "image": "mcr.microsoft.com/windows/servercore:ltsc2022",
       "container_dir": "c:/app",
       "windows_container": true,
       "commit": true


### PR DESCRIPTION
**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer Plugin PR:

https://github.com/hashicorp/packer-plugin-docker/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request

Update the documentation for Docker on windows where the docker image is no longer available and the example has a typo

