### PR TITLE
Log docker build from Dockerfile for debugging

### DIFF
--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -57,6 +57,8 @@ func (d *DockerDriver) Build(args []string) (string, error) {
 		return "", fmt.Errorf("%s build failed: %s; stdout: %s; stderr: %s", d.Executable, err, stdout.String(), stderr.String())
 	}
 
+	log.Print(stdout)
+
 	imageId, err := os.ReadFile(imageIdFilePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read image ID from file %q: %s", imageIdFilePath, err)


### PR DESCRIPTION
This PR has the only purpose to log the build from Dockerfile output when it succeeds. This can be extremely to review some actions which happened during the build.
It uses the `log.Print` so that it is only printed when debug mode is activated.

