### PR TITLE
Add build_only flag to skip provisioners and avoid /packer-files mount

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	// [Bootstrapping a build with a Dockerfile](#bootstrapping-a-build-with-a-dockerfile)
 	// section of this documentation.
 	BuildConfig DockerfileBootstrapConfig `mapstructure:"build"`
+	// If true, the resulting image will be built only using `build` section,
+	// which effectively means that the image will be buit using `docker build`
+	// command only.
+	BuildOnly bool `mapstructure:"build_only" required:"false"`
 	// Set the author (e-mail) of a commit.
 	Author string `mapstructure:"author"`
 	// Dockerfile instructions to add to the commit. Example of instructions

--- a/builder/docker/config.hcl2spec.go
+++ b/builder/docker/config.hcl2spec.go
@@ -99,6 +99,7 @@ type FlatConfig struct {
 	WinRMInsecure             *bool                          `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool                          `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 	BuildConfig               *FlatDockerfileBootstrapConfig `mapstructure:"build" cty:"build" hcl:"build"`
+	BuildOnly                 *bool                          `mapstructure:"build_only" cty:"build_only" hcl:"build_only"`
 	Author                    *string                        `mapstructure:"author" cty:"author" hcl:"author"`
 	Changes                   []string                       `mapstructure:"changes" cty:"changes" hcl:"changes"`
 	Commit                    *bool                          `mapstructure:"commit" required:"true" cty:"commit" hcl:"commit"`
@@ -204,6 +205,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"build":                        &hcldec.BlockSpec{TypeName: "build", Nested: hcldec.ObjectSpec((*FlatDockerfileBootstrapConfig)(nil).HCL2Spec())},
+		"build_only":                   &hcldec.AttrSpec{Name: "build_only", Type: cty.Bool, Required: false},
 		"author":                       &hcldec.AttrSpec{Name: "author", Type: cty.String, Required: false},
 		"changes":                      &hcldec.AttrSpec{Name: "changes", Type: cty.List(cty.String), Required: false},
 		"commit":                       &hcldec.AttrSpec{Name: "commit", Type: cty.Bool, Required: false},

--- a/docs-partials/builder/docker/Config-not-required.mdx
+++ b/docs-partials/builder/docker/Config-not-required.mdx
@@ -10,6 +10,8 @@
   [Bootstrapping a build with a Dockerfile](#bootstrapping-a-build-with-a-dockerfile)
   section of this documentation.
 
+- `build_only` (string) - If true, use `docker build` step only. Defaults to false.
+
 - `author` (string) - Set the author (e-mail) of a commit.
 
 - `changes` ([]string) - Dockerfile instructions to add to the commit. Example of instructions


### PR DESCRIPTION
This PR introduces a new `build_only` option to the Docker builder. When enabled, Packer will:
* Only execute the build block (equivalent to running docker build)
* Skip running any provisioners
* Avoid mounting the `/packer-files` directory into the container

Currently, Packer always mounts a host directory at /packer-files for provisioners. This directory is:
* Unmountable post-build (due to Docker limitations)
* Persisted in the final image, even if empty
* Not needed if provisioners aren’t used

This causes unnecessary artifacts in images and complicates reproducible builds. This issue is described in #134.

Benefits
* Cleaner final Docker images (no /packer-files directory)
* Improved reproducibility: image hashes remain stable for identical manifests
* More predictable builds for CI/CD pipelines using Docker-native workflows

Example usage:
```hcl2
source "docker" "postgres" {
  build {
    path = "Dockerfile"
  }
  build_only = true
  commit     = true
}
```
